### PR TITLE
Update todo-utils version. Fix dynamic paths in tests

### DIFF
--- a/__tests__/__fixtures__/eslint-with-errors.json
+++ b/__tests__/__fixtures__/eslint-with-errors.json
@@ -1,7 +1,7 @@
 {
   "results": [
     {
-      "filePath": "/Users/fake/app/controllers/settings.js",
+      "filePath": "{{path}}/app/controllers/settings.js",
       "messages": [
         {
           "ruleId": "no-prototype-builtins",
@@ -44,7 +44,7 @@
       "source": ""
     },
     {
-      "filePath": "/Users/fake/app/initializers/tracer.js",
+      "filePath": "{{path}}/app/initializers/tracer.js",
       "messages": [
         {
           "ruleId": "no-redeclare",
@@ -80,7 +80,7 @@
       "source": ""
     },
     {
-      "filePath": "/Users/fake/app/models/build.js",
+      "filePath": "{{path}}/app/models/build.js",
       "messages": [
         {
           "ruleId": "no-prototype-builtins",
@@ -112,7 +112,7 @@
       "source": ""
     },
     {
-      "filePath": "/Users/fake/app/services/insights.js",
+      "filePath": "{{path}}/app/services/insights.js",
       "messages": [
         {
           "ruleId": "no-prototype-builtins",
@@ -166,7 +166,7 @@
       "source": ""
     },
     {
-      "filePath": "/Users/fake/app/utils/traverse-payload.js",
+      "filePath": "{{path}}/app/utils/traverse-payload.js",
       "messages": [
         {
           "ruleId": "no-prototype-builtins",
@@ -187,7 +187,7 @@
       "source": ""
     },
     {
-      "filePath": "/Users/fake/tests/unit/services/insights-test.js",
+      "filePath": "{{path}}/tests/unit/services/insights-test.js",
       "messages": [
         {
           "ruleId": "no-prototype-builtins",

--- a/__tests__/__fixtures__/eslint-with-todos.json
+++ b/__tests__/__fixtures__/eslint-with-todos.json
@@ -1,7 +1,7 @@
 {
   "results": [
     {
-      "filePath": "/Users/fake/app/controllers/settings.js",
+      "filePath": "{{path}}/app/controllers/settings.js",
       "messages": [
         {
           "ruleId": "no-prototype-builtins",
@@ -45,7 +45,7 @@
       "source": ""
     },
     {
-      "filePath": "/Users/fake/app/initializers/tracer.js",
+      "filePath": "{{path}}/app/initializers/tracer.js",
       "messages": [
         {
           "ruleId": "no-redeclare",
@@ -82,7 +82,7 @@
       "source": ""
     },
     {
-      "filePath": "/Users/fake/app/models/build.js",
+      "filePath": "{{path}}/app/models/build.js",
       "messages": [
         {
           "ruleId": "no-prototype-builtins",
@@ -115,7 +115,7 @@
       "source": ""
     },
     {
-      "filePath": "/Users/fake/app/services/insights.js",
+      "filePath": "{{path}}/app/services/insights.js",
       "messages": [
         {
           "ruleId": "no-prototype-builtins",
@@ -170,7 +170,7 @@
       "source": ""
     },
     {
-      "filePath": "/Users/fake/app/utils/traverse-payload.js",
+      "filePath": "{{path}}/app/utils/traverse-payload.js",
       "messages": [
         {
           "ruleId": "no-prototype-builtins",
@@ -192,7 +192,7 @@
       "source": ""
     },
     {
-      "filePath": "/Users/fake/tests/unit/services/insights-test.js",
+      "filePath": "{{path}}/tests/unit/services/insights-test.js",
       "messages": [
         {
           "ruleId": "no-prototype-builtins",

--- a/__tests__/__utils__/fake-project.ts
+++ b/__tests__/__utils__/fake-project.ts
@@ -1,22 +1,64 @@
 import { execSync } from 'child_process';
 import Project from 'fixturify-project';
 
-const DEFAULT_ESLINT_CONFIG = `
-module.exports = {
-  env: {
-    browser: true,
-    es2021: true,
+const DEFAULT_ESLINT_CONFIG = `{
+  "env": {
+    "browser": true,
+    "es2021": true
   },
-  extends: [
-    'airbnb-base',
-  ],
-  parserOptions: {
-    ecmaVersion: 12,
-    sourceType: 'module',
+  "parserOptions": {
+    "ecmaVersion": 12,
+    "sourceType": "module"
   },
-  rules: {
-  },
-};
+  "rules": {
+    "no-alert": ["warn"],
+    "no-unused-vars": [
+      "error",
+      {
+        "vars": "all",
+        "args": "after-used",
+        "ignoreRestSiblings": true
+      }
+    ],
+    "use-isnan": ["error"],
+    "eqeqeq": [
+      "error",
+      "always",
+      {
+        "null": "ignore"
+      }
+    ],
+    "no-plusplus": ["error"],
+    "no-param-reassign": [
+      "error",
+      {
+        "props": true,
+        "ignorePropertyModificationsFor": [
+          "acc",
+          "accumulator",
+          "e",
+          "ctx",
+          "context",
+          "req",
+          "request",
+          "res",
+          "response",
+          "$scope",
+          "staticContext"
+        ]
+      }
+    ],
+    "consistent-return": ["error"],
+    "no-useless-return": ["error"],
+    "quotes": [
+      "error",
+      "single",
+      {
+        "avoidEscape": true
+      }
+    ]
+  }
+}
 `;
 
 export class FakeProject extends Project {
@@ -24,10 +66,8 @@ export class FakeProject extends Project {
     const project = new this();
 
     project.addDevDependency('eslint', '^7.10.0');
-    project.addDevDependency('eslint-plugin-import', '^2.22.1');
-    project.addDevDependency('eslint-config-airbnb-base', '^14.2.0');
 
-    project.files['.eslintrc.js'] = DEFAULT_ESLINT_CONFIG;
+    project.files['eslint-config.json'] = DEFAULT_ESLINT_CONFIG;
 
     return project;
   }

--- a/__tests__/__utils__/fake-project.ts
+++ b/__tests__/__utils__/fake-project.ts
@@ -1,7 +1,5 @@
 import { execSync } from 'child_process';
 import Project from 'fixturify-project';
-import { existsSync } from 'fs-extra';
-import { join } from 'path';
 
 const DEFAULT_ESLINT_CONFIG = `
 module.exports = {
@@ -39,13 +37,7 @@ export class FakeProject extends Project {
   }
 
   install(): void {
-    let cmd: string;
-
-    if (existsSync(join(this.baseDir, 'yarn.lock'))) {
-      cmd = 'yarn install';
-    } else {
-      cmd = 'npm install';
-    }
+    const cmd = 'yarn install';
 
     try {
       execSync(cmd, { cwd: this.baseDir });

--- a/__tests__/acceptance/eslint-with-todo-formatter-test.ts
+++ b/__tests__/acceptance/eslint-with-todo-formatter-test.ts
@@ -7,14 +7,15 @@ describe('eslint with todo formatter', function () {
   let project: FakeProject;
 
   function runEslintWithFormatter(options: execa.Options = {}) {
-    const defaultOptions = Object.assign(options);
-    defaultOptions.reject = false;
-    defaultOptions.cwd = options.cwd || project.baseDir;
+    const mergedOptions = Object.assign({
+      reject: false,
+      cwd: project.baseDir
+    }, options);
 
     return execa(
       './node_modules/.bin/eslint',
       ['src', '--format', require.resolve('../..')],
-      defaultOptions
+      mergedOptions
     );
   }
 
@@ -153,7 +154,6 @@ describe('eslint with todo formatter', function () {
 
   it('should emit errors, warnings, and todos when all of these are present and INCLUDE_TODO=1 is set', async () => {
     jest.setTimeout(5000000);
-    debugger;
     // first we generate project files with errors and convert them to todos
     project.files = {
       ...project.files,

--- a/__tests__/acceptance/eslint-with-todo-formatter-test.ts
+++ b/__tests__/acceptance/eslint-with-todo-formatter-test.ts
@@ -7,14 +7,24 @@ describe('eslint with todo formatter', function () {
   let project: FakeProject;
 
   function runEslintWithFormatter(options: execa.Options = {}) {
-    const mergedOptions = Object.assign({
-      reject: false,
-      cwd: project.baseDir
-    }, options);
+    const mergedOptions = Object.assign(
+      {
+        reject: false,
+        cwd: project.baseDir,
+      },
+      options
+    );
 
     return execa(
       './node_modules/.bin/eslint',
-      ['src', '--format', require.resolve('../..')],
+      [
+        'src',
+        '-c',
+        './eslint-config.json',
+        '--no-eslintrc',
+        '--format',
+        require.resolve('../..'),
+      ],
       mergedOptions
     );
   }
@@ -116,7 +126,7 @@ describe('eslint with todo formatter', function () {
     expect(stdout).toMatch(
       /1:10  todo  'fibonacci' is defined but never used\s+no-unused-vars/
     );
-    expect(stdout).toMatch(/✖ 0 problems \(0 errors, 0 warnings, 17 todos\)/);
+    expect(stdout).toMatch(/✖ 0 problems \(0 errors, 0 warnings, 10 todos\)/);
   });
 
   it('should emit todo items and count when INCLUDE_TODO=1 is set alone with prior todo items', async () => {
@@ -149,7 +159,7 @@ describe('eslint with todo formatter', function () {
     expect(stdout).toMatch(
       /1:10  todo  'fibonacci' is defined but never used\s+no-unused-vars/
     );
-    expect(stdout).toMatch(/✖ 0 problems \(0 errors, 0 warnings, 17 todos\)/);
+    expect(stdout).toMatch(/✖ 0 problems \(0 errors, 0 warnings, 10 todos\)/);
   });
 
   it('should emit errors, warnings, and todos when all of these are present and INCLUDE_TODO=1 is set', async () => {

--- a/__tests__/acceptance/eslint-with-todo-formatter-test.ts
+++ b/__tests__/acceptance/eslint-with-todo-formatter-test.ts
@@ -153,7 +153,6 @@ describe('eslint with todo formatter', function () {
   });
 
   it('should emit errors, warnings, and todos when all of these are present and INCLUDE_TODO=1 is set', async () => {
-    jest.setTimeout(5000000);
     // first we generate project files with errors and convert them to todos
     project.files = {
       ...project.files,

--- a/__tests__/acceptance/eslint-with-todo-formatter.ts
+++ b/__tests__/acceptance/eslint-with-todo-formatter.ts
@@ -22,8 +22,8 @@ describe('eslint with todo formatter', function () {
     project = FakeProject.getInstance();
   });
 
-  afterEach(async () => {
-    await project.dispose();
+  afterEach(() => {
+    project.dispose();
   });
 
   it('should not emit anything when there are no errors or warnings', async () => {
@@ -152,6 +152,8 @@ describe('eslint with todo formatter', function () {
   });
 
   it('should emit errors, warnings, and todos when all of these are present and INCLUDE_TODO=1 is set', async () => {
+    jest.setTimeout(5000000);
+    debugger;
     // first we generate project files with errors and convert them to todos
     project.files = {
       ...project.files,
@@ -178,7 +180,6 @@ describe('eslint with todo formatter', function () {
     };
 
     project.writeSync();
-    project.install();
 
     const result = await runEslintWithFormatter({
       env: { INCLUDE_TODO: '1' },

--- a/__tests__/unit/format-results-test.ts
+++ b/__tests__/unit/format-results-test.ts
@@ -1,6 +1,7 @@
 import {
   getTodoStorageDirPath,
   readTodos,
+  todoStorageDirExists,
 } from '@ember-template-lint/todo-utils';
 import { existsSync } from 'fs';
 import { DirResult, dirSync } from 'tmp';
@@ -43,10 +44,9 @@ describe('format-results', () => {
 
     await formatResultsAsync(results);
 
-    const todoDir = getTodoStorageDirPath(tmpDir.name);
-    expect(existsSync(todoDir)).toBe(true);
+    expect(todoStorageDirExists(tmpDir.name)).toBe(true);
 
-    const todos = await readTodos(todoDir);
+    const todos = await readTodos(tmpDir.name);
 
     expect(todos.size).toEqual(18);
   });

--- a/__tests__/unit/formatter-test.ts
+++ b/__tests__/unit/formatter-test.ts
@@ -4,33 +4,33 @@ import fixtures from '../__fixtures__/fixtures';
 
 describe('formatter', () => {
   it('should return all errors', async () => {
-    const results = fixtures.eslintWithErrors();
+    const results = fixtures.eslintWithErrors('/stable/path');
 
     expect(stripAnsi(formatter(results))).toMatchInlineSnapshot(`
       "
-      /Users/fake/app/controllers/settings.js
+      /stable/path/app/controllers/settings.js
          25:21  error  Do not access Object.prototype method 'hasOwnProperty' from target object  no-prototype-builtins
          26:19  error  Do not access Object.prototype method 'hasOwnProperty' from target object  no-prototype-builtins
          32:34  error  Do not access Object.prototype method 'hasOwnProperty' from target object  no-prototype-builtins
 
-      /Users/fake/app/initializers/tracer.js
+      /stable/path/app/initializers/tracer.js
          1:11  error  'window' is already defined as a built-in global variable          no-redeclare
          1:19  error  'XMLHttpRequest' is already defined as a built-in global variable  no-redeclare
 
-      /Users/fake/app/models/build.js
+      /stable/path/app/models/build.js
          108:50  error  Do not access Object.prototype method 'hasOwnProperty' from target object  no-prototype-builtins
          120:25  error  Do not access Object.prototype method 'hasOwnProperty' from target object  no-prototype-builtins
 
-      /Users/fake/app/services/insights.js
+      /stable/path/app/services/insights.js
          287:17  error  Do not access Object.prototype method 'hasOwnProperty' from target object  no-prototype-builtins
          296:17  error  Do not access Object.prototype method 'hasOwnProperty' from target object  no-prototype-builtins
          307:17  error  Do not access Object.prototype method 'hasOwnProperty' from target object  no-prototype-builtins
          317:17  error  Do not access Object.prototype method 'hasOwnProperty' from target object  no-prototype-builtins
 
-      /Users/fake/app/utils/traverse-payload.js
+      /stable/path/app/utils/traverse-payload.js
          18:18  error  Do not access Object.prototype method 'hasOwnProperty' from target object  no-prototype-builtins
 
-      /Users/fake/tests/unit/services/insights-test.js
+      /stable/path/tests/unit/services/insights-test.js
           65:27  error  Do not access Object.prototype method 'hasOwnProperty' from target object  no-prototype-builtins
           80:27  error  Do not access Object.prototype method 'hasOwnProperty' from target object  no-prototype-builtins
           97:27  error  Do not access Object.prototype method 'hasOwnProperty' from target object  no-prototype-builtins
@@ -46,40 +46,40 @@ describe('formatter', () => {
   });
 
   it('should not return anything when includeTodo is false and there are only todo items', async () => {
-    const results = fixtures.eslintWithTodos();
+    const results = fixtures.eslintWithTodos('/stable/path');
 
     expect(stripAnsi(formatter(results)).trim()).toEqual('');
   });
 
   it('should return all todo items when includeTodo is true', async () => {
-    const results = fixtures.eslintWithTodos();
+    const results = fixtures.eslintWithTodos('/stable/path');
 
     expect(stripAnsi(formatter(results, { includeTodo: true })))
       .toMatchInlineSnapshot(`
       "
-      /Users/fake/app/controllers/settings.js
+      /stable/path/app/controllers/settings.js
          25:21  todo  Do not access Object.prototype method 'hasOwnProperty' from target object  no-prototype-builtins
          26:19  todo  Do not access Object.prototype method 'hasOwnProperty' from target object  no-prototype-builtins
          32:34  todo  Do not access Object.prototype method 'hasOwnProperty' from target object  no-prototype-builtins
 
-      /Users/fake/app/initializers/tracer.js
+      /stable/path/app/initializers/tracer.js
          1:11  todo  'window' is already defined as a built-in global variable          no-redeclare
          1:19  todo  'XMLHttpRequest' is already defined as a built-in global variable  no-redeclare
 
-      /Users/fake/app/models/build.js
+      /stable/path/app/models/build.js
          108:50  todo  Do not access Object.prototype method 'hasOwnProperty' from target object  no-prototype-builtins
          120:25  todo  Do not access Object.prototype method 'hasOwnProperty' from target object  no-prototype-builtins
 
-      /Users/fake/app/services/insights.js
+      /stable/path/app/services/insights.js
          287:17  todo  Do not access Object.prototype method 'hasOwnProperty' from target object  no-prototype-builtins
          296:17  todo  Do not access Object.prototype method 'hasOwnProperty' from target object  no-prototype-builtins
          307:17  todo  Do not access Object.prototype method 'hasOwnProperty' from target object  no-prototype-builtins
          317:17  todo  Do not access Object.prototype method 'hasOwnProperty' from target object  no-prototype-builtins
 
-      /Users/fake/app/utils/traverse-payload.js
+      /stable/path/app/utils/traverse-payload.js
          18:18  todo  Do not access Object.prototype method 'hasOwnProperty' from target object  no-prototype-builtins
 
-      /Users/fake/tests/unit/services/insights-test.js
+      /stable/path/tests/unit/services/insights-test.js
           65:27  todo  Do not access Object.prototype method 'hasOwnProperty' from target object  no-prototype-builtins
           80:27  todo  Do not access Object.prototype method 'hasOwnProperty' from target object  no-prototype-builtins
           97:27  todo  Do not access Object.prototype method 'hasOwnProperty' from target object  no-prototype-builtins

--- a/__tests__/unit/mutate-errors-to-todos-test.ts
+++ b/__tests__/unit/mutate-errors-to-todos-test.ts
@@ -7,7 +7,6 @@ describe('mutate-errors-to-todos', () => {
   it('changes only the errors that are also present in the todo map to todos', async () => {
     const tmp = dirSync({ unsafeCleanup: true });
     const results = fixtures.eslintWithErrors(tmp.name);
-    debugger;
 
     // build todo map but without the last result in the results array (so they differ)
     const todoResults = [...results];

--- a/__tests__/unit/mutate-errors-to-todos-test.ts
+++ b/__tests__/unit/mutate-errors-to-todos-test.ts
@@ -1,17 +1,20 @@
 import { buildTodoData } from '@ember-template-lint/todo-utils';
+import { dirSync } from 'tmp';
 import { mutateTodoErrorsToTodos } from '../../src/mutate-errors-to-todos';
 import fixtures from '../__fixtures__/fixtures';
 
 describe('mutate-errors-to-todos', () => {
   it('changes only the errors that are also present in the todo map to todos', async () => {
-    const results = fixtures.eslintWithErrors();
+    const tmp = dirSync({ unsafeCleanup: true });
+    const results = fixtures.eslintWithErrors(tmp.name);
+    debugger;
 
     // build todo map but without the last result in the results array (so they differ)
     const todoResults = [...results];
     const lastResult = todoResults.pop();
-    const todos = buildTodoData(todoResults);
+    const todos = buildTodoData(tmp.name, todoResults);
 
-    mutateTodoErrorsToTodos(results, todos);
+    mutateTodoErrorsToTodos(tmp.name, results, todos);
 
     // last result should stay unchanged
     expect(results[results.length - 1]).toEqual(lastResult);

--- a/__tests__/unit/utils-test.ts
+++ b/__tests__/unit/utils-test.ts
@@ -1,4 +1,4 @@
-import { getBasePath } from '../../src/utils';
+import { getBaseDir } from '../../src/get-base-dir';
 
 describe('utils', () => {
   const INITIAL_ENV = process.env;
@@ -14,10 +14,10 @@ describe('utils', () => {
   it('returns the path passed as ENV variable', () => {
     const eslintTodoDir = 'eslint-todo-dir';
     process.env.ESLINT_TODO_DIR = eslintTodoDir;
-    expect(getBasePath()).toEqual(eslintTodoDir);
+    expect(getBaseDir()).toEqual(eslintTodoDir);
   });
 
   it('returns current working dir if no ENV variable was passed', () => {
-    expect(getBasePath()).toEqual(process.cwd());
+    expect(getBaseDir()).toEqual(process.cwd());
   });
 });

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "jest --passWithNoTests --no-cache"
   },
   "dependencies": {
-    "@ember-template-lint/todo-utils": "^2.2.0",
+    "@ember-template-lint/todo-utils": "^3.0.0",
     "chalk": "^4.1.0",
     "eslint": "^7.10.0",
     "strip-ansi": "^6.0.0",

--- a/src/format-results.ts
+++ b/src/format-results.ts
@@ -1,14 +1,13 @@
 import {
-  getTodoStorageDirPath,
   readTodos,
+  todoStorageDirExists,
   writeTodos,
 } from '@ember-template-lint/todo-utils';
 import type { ESLint } from 'eslint';
-import { existsSync } from 'fs';
 import { formatter } from './formatter';
 import { mutateTodoErrorsToTodos } from './mutate-errors-to-todos';
 import { TodoFormatterOptions } from './types';
-import { getBasePath } from './utils';
+import { getBaseDir } from './get-base-dir';
 
 function formatResults(results: ESLint.LintResult[]): void {
   // note: using async/await directly causes eslint to print `Promise { <pending> }`
@@ -20,7 +19,7 @@ async function formatResultsAsync(results: ESLint.LintResult[]): Promise<void> {
   const includeTodo = process.env.INCLUDE_TODO === '1';
 
   if (shouldUpdateTodo) {
-    await writeTodos(getBasePath(), results);
+    await writeTodos(getBaseDir(), results);
   }
 
   await report(results, { includeTodo });
@@ -30,11 +29,11 @@ async function report(
   results: ESLint.LintResult[],
   options: TodoFormatterOptions
 ) {
-  const todoDir = getTodoStorageDirPath(getBasePath());
+  const baseDir = getBaseDir();
 
-  if (existsSync(todoDir)) {
-    const todos = await readTodos(todoDir);
-    await mutateTodoErrorsToTodos(results, todos);
+  if (todoStorageDirExists(baseDir)) {
+    const todos = await readTodos(baseDir);
+    await mutateTodoErrorsToTodos(baseDir, results, todos);
   }
 
   process.stdout.write(formatter(results, options));

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -1,7 +1,7 @@
 import { blueBright, dim, red, reset, underline, yellow } from 'chalk';
-import { ESLint } from 'eslint';
 import stripAnsi from 'strip-ansi';
 import table from 'text-table';
+import type { ESLint } from 'eslint';
 import type {
   TodoFormatterCounts,
   TodoFormatterOptions,

--- a/src/get-base-dir.ts
+++ b/src/get-base-dir.ts
@@ -1,3 +1,3 @@
-export function getBasePath(): string {
+export function getBaseDir(): string {
   return process.env.ESLINT_TODO_DIR || process.cwd();
 }

--- a/src/mutate-errors-to-todos.ts
+++ b/src/mutate-errors-to-todos.ts
@@ -11,6 +11,7 @@ import type { TodoResultMessage } from './types';
  * @param results ESLint results array
  */
 export async function mutateTodoErrorsToTodos(
+  baseDir: string,
   results: ESLint.LintResult[],
   todoMap: Map<string, TodoData>
 ): Promise<void> {
@@ -21,7 +22,7 @@ export async function mutateTodoErrorsToTodos(
       }
 
       // we only mutate errors that are present in the todo map, so check if it's there first
-      const todoDatum = _buildTodoDatum(result, message as Linter.LintMessage);
+      const todoDatum = _buildTodoDatum(baseDir, result, message as Linter.LintMessage);
 
       const todoHash = todoFilePathFor(todoDatum);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -271,10 +271,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@ember-template-lint/todo-utils@^2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@ember-template-lint/todo-utils/-/todo-utils-2.2.0.tgz#4b5018e4f63dc3342f80e233a1b9acf75e9600e2"
-  integrity sha512-vVq4Blj6e8IFMVnsYSuRoZHNMrJ457udi7cpJS13W+VCIbNVtIV9RIV1lm+sUmtA1RiVdBA0Gi1Pop06lUKCSg==
+"@ember-template-lint/todo-utils@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@ember-template-lint/todo-utils/-/todo-utils-3.0.0.tgz#7b4da8b0ea1e015b05c183e5ae13aafe0c30973c"
+  integrity sha512-Mkbh6ZYPs/gWCcQly1hSAPEa03EPE4DCaBKnBvlNM9udoghvc29sYgn49/TUIVCzLkWrtmVWjboxcB1LoXdHCg==
   dependencies:
     fs-extra "^9.0.1"
 


### PR DESCRIPTION
Updates `@ember-template-lint/todo-utils` to latest version, fixes API changes. 

Also addresses tests that had fixtures that weren't representative of true lint results.