### PR TITLE
fix: Output summary counts and spacing

### DIFF
--- a/__tests__/__fixtures__/eslint-with-todos.json
+++ b/__tests__/__fixtures__/eslint-with-todos.json
@@ -79,6 +79,7 @@
       "todoCount": 2,
       "fixableErrorCount": 0,
       "fixableWarningCount": 0,
+      "fixableTodoCount": 1,
       "source": ""
     },
     {

--- a/__tests__/acceptance/eslint-with-todo-formatter-test.ts
+++ b/__tests__/acceptance/eslint-with-todo-formatter-test.ts
@@ -79,7 +79,7 @@ describe('eslint with todo formatter', function () {
     );
     expect(stdout).toMatch(/✖ 3 problems \(2 errors, 1 warning\)/);
     expect(stdout).toMatch(
-      /1 error and warnings potentially fixable with the `--fix` option\./
+      /1 error and 0 warnings potentially fixable with the `--fix` option\./
     );
   });
 

--- a/__tests__/unit/formatter-test.ts
+++ b/__tests__/unit/formatter-test.ts
@@ -39,7 +39,7 @@ describe('formatter', () => {
          158:32  error  Do not access Object.prototype method 'hasOwnProperty' from target object  no-prototype-builtins
 
       ✖ 18 problems (18 errors, 0 warnings)
-        1 error and warnings potentially fixable with the \`--fix\` option.
+        1 error and 0 warnings potentially fixable with the \`--fix\` option.
 
       "
     `);
@@ -111,7 +111,7 @@ describe('formatter', () => {
          3:3   warning  Unexpected alert                                           no-alert
 
       ✖ 6 problems (4 errors, 2 warnings)
-        1 error and warnings potentially fixable with the \`--fix\` option.
+        1 error and 0 warnings potentially fixable with the \`--fix\` option.
 
       "
     `);

--- a/__tests__/unit/formatter-test.ts
+++ b/__tests__/unit/formatter-test.ts
@@ -88,6 +88,7 @@ describe('formatter', () => {
          158:32  todo  Do not access Object.prototype method 'hasOwnProperty' from target object  no-prototype-builtins
 
       ✖ 0 problems (0 errors, 0 warnings, 18 todos)
+        0 errors, 0 warnings, and 1 todo potentially fixable with the \`--fix\` option.
 
       "
     `);

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -154,12 +154,12 @@ function formatSummary(
             '  ',
             fixableErrorCount,
             pluralize(' error', fixableErrorCount),
-            ',',
+            ', ',
             fixableWarningCount,
             pluralize(' warning', fixableWarningCount),
             ', and ',
             fixableTodoCount,
-            pluralize('todo', fixableTodoCount),
+            pluralize(' todo', fixableTodoCount),
           ]
         : [
             '  ',

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -155,15 +155,18 @@ function formatSummary(
             fixableErrorCount,
             pluralize(' error', fixableErrorCount),
             ',',
+            fixableWarningCount,
             pluralize(' warning', fixableWarningCount),
-            ', and',
+            ', and ',
+            fixableTodoCount,
             pluralize('todo', fixableTodoCount),
           ]
         : [
             '  ',
             fixableErrorCount,
             pluralize(' error', fixableErrorCount),
-            ' and',
+            ' and ',
+            fixableWarningCount,
             pluralize(' warning', fixableWarningCount),
           ];
 


### PR DESCRIPTION
Fixes indentation and correctly including counts for all violation types.

Before:

<img width="830" alt="Screen Shot 2020-11-30 at 3 41 24 PM" src="https://user-images.githubusercontent.com/180990/100811987-d6921e80-33f0-11eb-89eb-71c6dd04aae4.png">

After:

<img width="810" alt="Screen Shot 2020-12-01 at 4 16 18 PM" src="https://user-images.githubusercontent.com/180990/100811917-a9de0700-33f0-11eb-93ed-ba593db20604.png">
