### PR TITLE
Enable removal of outstanding todos with --fix

### DIFF
--- a/__tests__/__fixtures__/no-errors.js
+++ b/__tests__/__fixtures__/no-errors.js
@@ -1,0 +1,5 @@
+function addOne(i) {
+  return i + 1;
+}
+
+addOne(1);

--- a/__tests__/__fixtures__/with-fixable-error.js
+++ b/__tests__/__fixtures__/with-fixable-error.js
@@ -1,0 +1,3 @@
+function addOne(i) {
+  return i + 1;
+}

--- a/__tests__/__utils__/fake-project.ts
+++ b/__tests__/__utils__/fake-project.ts
@@ -1,4 +1,5 @@
 import { execSync } from 'child_process';
+import fixturify from 'fixturify';
 import Project from 'fixturify-project';
 
 const DEFAULT_ESLINT_CONFIG = `{
@@ -74,10 +75,21 @@ export class FakeProject extends Project {
 
   constructor(name = 'fake-project', ...args: any[]) {
     super(name, ...args);
+
+    this.pkg = Object.assign({}, this.pkg, {
+      license: 'MIT',
+      description: 'Fake project',
+      repository: 'http://fakerepo.com',
+    });
+  }
+
+  write(dirJSON: fixturify.DirJSON): void {
+    Object.assign(this.files, dirJSON);
+    this.writeSync();
   }
 
   install(): void {
-    const cmd = 'yarn install';
+    const cmd = 'yarn install --silent';
 
     try {
       execSync(cmd, { cwd: this.baseDir });

--- a/__tests__/acceptance/eslint-with-todo-formatter-test.ts
+++ b/__tests__/acceptance/eslint-with-todo-formatter-test.ts
@@ -15,11 +15,11 @@ describe('eslint with todo formatter', function () {
   ) {
     if (arguments.length > 0) {
       if (arguments.length === 1) {
-        if (typeof argsOrOptions === 'object') {
+        if (Array.isArray(argsOrOptions)) {
+          options = {};
+        } else {
           options = argsOrOptions as execa.Options;
           argsOrOptions = [];
-        } else {
-          options = {};
         }
       }
     } else {
@@ -238,6 +238,7 @@ describe('eslint with todo formatter', function () {
     `);
 
     // run fix, and expect that this will delete the outstanding todo item
+    debugger;
     await runEslintWithFormatter(['--fix']);
 
     // run normally again and expect no error

--- a/__tests__/acceptance/eslint-with-todo-formatter-test.ts
+++ b/__tests__/acceptance/eslint-with-todo-formatter-test.ts
@@ -229,16 +229,12 @@ describe('eslint with todo formatter', function () {
 
     // run normally and expect an error for not running --fix
     let result = await runEslintWithFormatter();
-    let stdout = stripAnsi(result.stdout);
 
-    expect(stdout).toMatchInlineSnapshot(`
-      "
-      src/with-fixable-error.js
+    expect(stripAnsi(result.stdout).trim()).toMatchInlineSnapshot(`
+      "src/with-fixable-error.js
          0:0  error  Todo violation passes \`no-unused-vars\` rule. Please run \`--fix\` to remove this todo from the todo list  invalid-todo-violation-rule
 
-      ✖ 1 problem (1 error, 0 warnings)
-
-      "
+      ✖ 1 problem (1 error, 0 warnings)"
     `);
 
     // run fix, and expect that this will delete the outstanding todo item
@@ -246,7 +242,6 @@ describe('eslint with todo formatter', function () {
 
     // run normally again and expect no error
     result = await runEslintWithFormatter();
-    stdout = stripAnsi(result.stdout);
 
     const todoStorageDir = getTodoStorageDirPath(project.baseDir);
     const todos = readdirSync(
@@ -254,7 +249,7 @@ describe('eslint with todo formatter', function () {
     );
 
     expect(result.exitCode).toEqual(0);
-    expect(stdout).toEqual('');
+    expect(stripAnsi(result.stdout).trim()).toEqual('');
     expect(todos).toHaveLength(0);
   });
 });

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "clean": "tsc --build --clean",
     "lint": "eslint . --ext .ts",
     "prepare": "yarn build",
-    "test": "jest --passWithNoTests --no-cache"
+    "test": "jest --no-cache"
   },
   "dependencies": {
     "@ember-template-lint/todo-utils": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build": "tsc --build",
     "build:watch": "tsc --watch",
     "clean": "tsc --build --clean",
-    "lint": "eslint . --ext js, ts",
+    "lint": "eslint . --ext .ts",
     "prepare": "yarn build",
     "test": "jest --passWithNoTests --no-cache"
   },

--- a/package.json
+++ b/package.json
@@ -17,14 +17,15 @@
     "build": "tsc --build",
     "build:watch": "tsc --watch",
     "clean": "tsc --build --clean",
-    "lint": "eslint . --ext .ts",
+    "lint": "eslint . --ext js, ts",
     "prepare": "yarn build",
     "test": "jest --passWithNoTests --no-cache"
   },
   "dependencies": {
-    "@ember-template-lint/todo-utils": "^3.0.0",
+    "@ember-template-lint/todo-utils": "^3.1.0",
     "chalk": "^4.1.0",
     "eslint": "^7.10.0",
+    "has-flag": "^4.0.0",
     "strip-ansi": "^6.0.0",
     "text-table": "^0.2.0"
   },

--- a/src/format-results.ts
+++ b/src/format-results.ts
@@ -39,14 +39,10 @@ async function report(
 
   if (todoStorageDirExists(baseDir)) {
     const existingTodoFiles = await readTodos(baseDir);
-    console.log(JSON.stringify(results, undefined, 2));
     const [, itemsToRemoveFromTodos,] = await getTodoBatches(
       buildTodoData(baseDir, results),
       existingTodoFiles
     );
-
-    console.log('Items to remove:', itemsToRemoveFromTodos.size);
-    console.log('Fix:', hasFlag('fix'));
 
     if (itemsToRemoveFromTodos.size > 0) {
       if (hasFlag('fix')) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -278,7 +278,7 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@ember-template-lint/todo-utils@^3.0.0":
+"@ember-template-lint/todo-utils@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@ember-template-lint/todo-utils/-/todo-utils-3.1.0.tgz#4273dcf4f9ba5d1929084bdd0b2b1f0ab66f2f30"
   integrity sha512-sUmKf8kTpqhgKbSyX9pLQ4kAhGA6vWgnpflYCWWMJ9CdtsldGtwUJb5eONMJNhhZOsfRpBpIrYa2SiXJ2b/Wgg==


### PR DESCRIPTION
When a lint error is opted into the TODO system, a JSON file is used to track that as a TODO, and the error is subsequently transformed into a TODO in the lint result by changing the severity to -1. If a user fixes the original error, we'd ideally like to delete the corresponding TODO file, so that it's removed from TODO tracking. In order to support this, this PR adds the ability to delete outstanding TODO files that no longer have a corresponding error by using the `--fix` option.

Example:

When an error is fixed, but we still have an outstanding TODO:

![todo-fix](https://user-images.githubusercontent.com/180990/102680260-8d212d80-416b-11eb-9b93-5e0087b071b4.png)

After running with `--fix`, the TODO will be removed, and no error will be generated.