### PR TITLE
Converts to sync APIs

### DIFF
--- a/__tests__/acceptance/eslint-with-todo-formatter-test.ts
+++ b/__tests__/acceptance/eslint-with-todo-formatter-test.ts
@@ -69,6 +69,7 @@ describe('eslint with todo formatter', function () {
     const result = await runEslintWithFormatter();
 
     expect(result.stdout).toEqual('');
+    expect(result.exitCode).toEqual(0);
   });
 
   it('should emit errors and warnings as normal', async () => {
@@ -82,9 +83,9 @@ describe('eslint with todo formatter', function () {
     project.install();
 
     const result = await runEslintWithFormatter();
-
     const stdout = stripAnsi(result.stdout);
 
+    expect(result.exitCode).toEqual(1);
     expect(stdout).toMatch(
       /1:10  error {4}'sayHi' is defined but never used  no-unused-vars/
     );
@@ -111,6 +112,7 @@ describe('eslint with todo formatter', function () {
       env: { UPDATE_TODO: '1' },
     });
 
+    expect(result.exitCode).toEqual(0);
     expect(stripAnsi(result.stdout).trim()).toEqual('');
   });
 
@@ -126,9 +128,9 @@ describe('eslint with todo formatter', function () {
     const result = await runEslintWithFormatter({
       env: { UPDATE_TODO: '1', INCLUDE_TODO: '1' },
     });
-
     const stdout = stripAnsi(result.stdout);
 
+    expect(result.exitCode).toEqual(0);
     expect(stdout).toMatch(
       /1:10  todo  'addOne' is defined but never used\s+no-unused-vars/
     );
@@ -159,6 +161,7 @@ describe('eslint with todo formatter', function () {
 
     const stdout = stripAnsi(result.stdout);
 
+    expect(result.exitCode).toEqual(0);
     expect(stdout).toMatch(
       /1:10  todo  'addOne' is defined but never used\s+no-unused-vars/
     );
@@ -196,6 +199,7 @@ describe('eslint with todo formatter', function () {
 
     const stdout = stripAnsi(result.stdout);
 
+    expect(result.exitCode).toEqual(1);
     expect(stdout).toMatch(
       /1:10  todo  'addOne' is defined but never used\s+no-unused-vars/
     );
@@ -214,7 +218,6 @@ describe('eslint with todo formatter', function () {
     });
     project.install();
 
-    debugger;
     // generate todo based on existing error
     await runEslintWithFormatter({
       env: { UPDATE_TODO: '1' },
@@ -230,6 +233,7 @@ describe('eslint with todo formatter', function () {
     // run normally and expect an error for not running --fix
     let result = await runEslintWithFormatter();
 
+    expect(result.exitCode).toEqual(1);
     expect(stripAnsi(result.stdout).trim()).toMatchInlineSnapshot(`
       "src/with-fixable-error.js
          0:0  error  Todo violation passes \`no-unused-vars\` rule. Please run \`--fix\` to remove this todo from the todo list  invalid-todo-violation-rule
@@ -238,7 +242,6 @@ describe('eslint with todo formatter', function () {
     `);
 
     // run fix, and expect that this will delete the outstanding todo item
-    debugger;
     await runEslintWithFormatter(['--fix']);
 
     // run normally again and expect no error

--- a/__tests__/unit/formatter-test.ts
+++ b/__tests__/unit/formatter-test.ts
@@ -2,12 +2,13 @@ import {
   buildTodoData,
   getTodoStorageDirPath,
   readTodos,
+  readTodosSync,
   todoStorageDirExists,
 } from '@ember-template-lint/todo-utils';
 import { existsSync } from 'fs';
 import { DirResult, dirSync } from 'tmp';
 import { TODO_SEVERITY } from '../../src/constants';
-import { formatterAsync, transformResults } from '../../src/formatter';
+import { formatter, transformResults } from '../../src/formatter';
 import fixtures from '../__fixtures__/fixtures';
 import { deepCopy } from '../__utils__/deep-copy';
 import { setUpdateTodoEnv } from '../__utils__/set-env';
@@ -28,54 +29,54 @@ describe('format-results', () => {
     process.env = INITIAL_ENV;
   });
 
-  it('SHOULD NOT generate a TODO dir with todo files when UPDATE_TODO is set to 0', async () => {
+  it('SHOULD NOT generate a TODO dir with todo files when UPDATE_TODO is set to 0', () => {
     setUpdateTodoEnv(false);
 
     const results = fixtures.eslintWithErrors(tmpDir.name);
 
-    await formatterAsync(results);
+    formatter(results);
 
     const todoDir = getTodoStorageDirPath(tmpDir.name);
     expect(existsSync(todoDir)).toBe(false);
   });
 
-  it('SHOULD generate a TODO dir with todo files when UPDATE_TODO is set to 1', async () => {
+  it('SHOULD generate a TODO dir with todo files when UPDATE_TODO is set to 1', () => {
     setUpdateTodoEnv(true);
 
     const results = fixtures.eslintWithErrors(tmpDir.name);
 
-    await formatterAsync(results);
+    formatter(results);
 
     expect(todoStorageDirExists(tmpDir.name)).toBe(true);
 
-    const todos = await readTodos(tmpDir.name);
+    const todos = readTodosSync(tmpDir.name);
 
     expect(todos.size).toEqual(18);
   });
 
-  it('SHOULD not mutate errors if a todo dir is not present', async () => {
+  it('SHOULD not mutate errors if a todo dir is not present', () => {
     setUpdateTodoEnv(false);
 
     const results = fixtures.eslintWithErrors(tmpDir.name);
     const expected = deepCopy(results);
 
-    await formatterAsync(results);
+    formatter(results);
 
     expect(results).toEqual(expected);
   });
 
-  it('SHOULD mutate errors when a todo dir is present', async () => {
+  it('SHOULD mutate errors when a todo dir is present', () => {
     setUpdateTodoEnv(true);
 
     const results = fixtures.eslintWithErrors(tmpDir.name);
     const notExpected = deepCopy(results);
 
-    await formatterAsync(results);
+    formatter(results);
 
     expect(results).not.toEqual(notExpected);
   });
 
-  it('changes only the errors that are also present in the todo map to todos', async () => {
+  it('changes only the errors that are also present in the todo map to todos', () => {
     const results = fixtures.eslintWithErrors(tmpDir.name);
 
     // build todo map but without the last result in the results array (so they differ)

--- a/__tests__/unit/formatter-test.ts
+++ b/__tests__/unit/formatter-test.ts
@@ -1,7 +1,6 @@
 import {
   buildTodoData,
   getTodoStorageDirPath,
-  readTodos,
   readTodosSync,
   todoStorageDirExists,
 } from '@ember-template-lint/todo-utils';

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "jest --no-cache"
   },
   "dependencies": {
-    "@ember-template-lint/todo-utils": "^3.1.0",
+    "@ember-template-lint/todo-utils": "^3.3.0",
     "chalk": "^4.1.0",
     "eslint": "^7.10.0",
     "has-flag": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -278,10 +278,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@ember-template-lint/todo-utils@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@ember-template-lint/todo-utils/-/todo-utils-3.1.0.tgz#4273dcf4f9ba5d1929084bdd0b2b1f0ab66f2f30"
-  integrity sha512-sUmKf8kTpqhgKbSyX9pLQ4kAhGA6vWgnpflYCWWMJ9CdtsldGtwUJb5eONMJNhhZOsfRpBpIrYa2SiXJ2b/Wgg==
+"@ember-template-lint/todo-utils@^3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@ember-template-lint/todo-utils/-/todo-utils-3.3.0.tgz#4273c2bcad211a52e5b7a98a1642df9b9bfe50a0"
+  integrity sha512-niGygekKJ/d14U+HpDPPaZA66BfuB0cPmftF821RrOuw3ols5cSOepy8WwIuMp7L7JXKLkN2Hj+idHlza9p3Yw==
   dependencies:
     fs-extra "^9.0.1"
     slash "^3.0.0"


### PR DESCRIPTION
Using the async APIs in `@ember-template-lint/todo-utils` resulted in eslint not correctly waiting for the result to be mutated. This caused the exit codes to be incorrect, giving the wrong signal to users when using this formatter. This PR uses the new sync APIs from that package, which has addressed the issue.