### PR TITLE
Adds output feedback when creating TODOs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,26 +20,18 @@ This formatter allows you to introduce new rules immediately, without blocking c
 
 ## Usage
 
-When you introduce new linting rules, execute ESLint by setting `UPDATE_TODO=1` and passing the formatter.
+TODOs are stored in a `.lint-todo` directory that should be checked in with other source code. Each error generates a unique file, allowing for multiple errors within a single file to be resolved individually with minimal conflicts.
+
+To convert errors to TODOs, you can use the `UPDATE_TODO` environment variable. This will convert all active errors to TODOs, hiding them from the linting output.
 
 ```bash
-$ UPDATE_TODO=1 eslint --format @scalvert/eslint-formatter-todo
+UPDATE_TODO=1 eslint --format @scalvert/eslint-formatter-todo
 ```
 
-This command will transform all reported `error`s to `todo`s and will generate files inside the `.lint-todo` directory to track them.
-
-Executing ESLint without `UPDATE_TODO=1` will run `eslint` normally but will transform errors that are present in the `.lint-todo` directory to `todo` items, not displaying them as errors.
+If you want to see TODOs as part of `eslint`'s output, you can include them
 
 ```bash
-$ eslint --format @scalvert/eslint-formatter-todo
-
-# no output, no errors
-```
-
-To have `todo`s to appear in results, set `INCLUDE_TODO=1`.
-
-```bash
-$ INCLUDE_TODO=1 eslint --format @scalvert/eslint-formatter-todo
+INCLUDE_TODO=1 eslint --format @scalvert/eslint-formatter-todo
 
 /path/to/file/fullOfProblems.js
    2:7   todo  Use the isNaN function to compare with NaN  use-isnan
@@ -47,4 +39,74 @@ $ INCLUDE_TODO=1 eslint --format @scalvert/eslint-formatter-todo
    3:12  todo  Unary operator '++' used                    no-plusplus
 
 ✖ 0 problems (0 errors, 0 warnings, 3 todos)
+```
+
+If an error is fixed manually, `eslint` will let you know that there's an outstanding TODO file. You can remove this file by running `--fix`
+
+```bash
+eslint . --format @scalvert/eslint-formatter-todo --fix
+```
+
+### Configuring Due Dates
+
+TODOs can be created with optional due dates. These due dates allow for TODOs to, over a period of time, 'decay' the severity to a **warning** and/or **error** after a certain date. This helps ensure that TODOs are created but not forgotten, and can allow for better managing incremental roll-outs of large-scale or slow-to-fix rules.
+
+Due dates can be configured in multiple ways, but all specify integers for `warn` and `error` to signify the number of days from the TODO created date to decay the severity.
+
+:bulb: Both `warn` and `error` are optional. The value for `warn` should be greater than the value of `error`.
+
+1. Via package.json configuration
+
+```json
+{
+  "lintTodo": {
+    "decayDays": {
+      "warn": 5,
+      "error": 10
+    }
+  }
+}
+```
+
+1. Via environment variables
+
+```bash
+UPDATE_TODO='1' TODO_DAYS_TO_WARN="5" TODO_DAYS_TO_ERROR="10" eslint . --format @scalvert/eslint-formatter-todo
+```
+
+In order of precedence, environment variables override package.json configuration values.
+
+For example, if you've specified the following values in the package.json configuration...
+
+```json
+{
+  "lintTodo": {
+    "decayDays": {
+      "warn": 5,
+      "error": 10
+    }
+  }
+}
+```
+
+...and you supply the following environment variables:
+
+```bash
+UPDATE_TODO='1' TODO_DAYS_TO_WARN= '2' eslint . --format @scalvert/eslint-formatter-todo
+```
+
+...the TODOs will be created with a `warn` date 2 days from the created date, and an `error` date 10 days from the created date.
+
+### Due Date Workflows
+
+Converting errors to TODOs with `warn` and `error` dates that transition the TODO to `warn` after 10 days and `error` after 20 days:
+
+```bash
+UPDATE_TODO='1' TODO_DAYS_TO_WARN= '10' TODO_DAYS_TO_ERROR='20' eslint . --format @scalvert/eslint-formatter-todo
+```
+
+Converting errors to TODOs with `warn` and `error` dates that transition the TODO `error` after 20 days, but doesn't include a `warn` date:
+
+```bash
+UPDATE_TODO='1' TODO_DAYS_TO_WARN= '' TODO_DAYS_TO_ERROR='20' eslint . --format @scalvert/eslint-formatter-todo
 ```

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ eslint . --format @scalvert/eslint-formatter-todo --fix
 
 TODOs can be created with optional due dates. These due dates allow for TODOs to, over a period of time, 'decay' the severity to a **warning** and/or **error** after a certain date. This helps ensure that TODOs are created but not forgotten, and can allow for better managing incremental roll-outs of large-scale or slow-to-fix rules.
 
-Due dates can be configured in multiple ways, but all specify integers for `warn` and `error` to signify the number of days from the TODO created date to decay the severity.
+Due dates can be configured in one of two ways, but both specify integers for `warn` and `error` to signify the number of days from the TODO created date to decay the severity.
 
 :bulb: Both `warn` and `error` are optional. The value for `warn` should be greater than the value of `error`.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ An ESLint formatter that can report errors as TODOs, which can be deferred and f
 
 <img src="docs/post-todo.png" style="background-color: #fff" />
 
-A TODO is an existing linting error present in the project, but one that is transitioned into a new severity level: TODO. This allows for incremental fixing of linting errors in very large projects, where the resolution or introduction of errors can cause undesired degradation in engineer velocity.
+A `todo` is an existing linting error present in the project, but one that is transitioned into a new severity level: `todo`. This allows for incremental fixing of linting errors in very large projects, where the resolution or introduction of errors can cause undesired degradation in engineer velocity.
 
 When introducing new linting rules to your project, it is possible that you may find many linting errors. If your CI is set up to prevent commits when lint errors are encountered, your team will have to fix all errors before you can add these new rules to your project, leading to a delayed introduction of the rules.
 
@@ -41,7 +41,7 @@ INCLUDE_TODO=1 eslint --format @scalvert/eslint-formatter-todo
 ✖ 0 problems (0 errors, 0 warnings, 3 todos)
 ```
 
-If an error is fixed manually, `eslint` will let you know that there's an outstanding TODO file. You can remove this file by running `--fix`
+If an error is fixed manually, `eslint` will let you know that there's an outstanding `todo` file. You can remove this file by running `--fix`
 
 ```bash
 eslint . --format @scalvert/eslint-formatter-todo --fix
@@ -51,7 +51,7 @@ eslint . --format @scalvert/eslint-formatter-todo --fix
 
 TODOs can be created with optional due dates. These due dates allow for TODOs to, over a period of time, 'decay' the severity to a **warning** and/or **error** after a certain date. This helps ensure that TODOs are created but not forgotten, and can allow for better managing incremental roll-outs of large-scale or slow-to-fix rules.
 
-Due dates can be configured in one of two ways, but both specify integers for `warn` and `error` to signify the number of days from the TODO created date to decay the severity.
+Due dates can be configured in one of two ways, but both specify integers for `warn` and `error` to signify the number of days from the `todo` created date to decay the severity.
 
 :bulb: Both `warn` and `error` are optional. The value for `warn` should be greater than the value of `error`.
 
@@ -99,13 +99,13 @@ UPDATE_TODO='1' TODO_DAYS_TO_WARN= '2' eslint . --format @scalvert/eslint-format
 
 ### Due Date Workflows
 
-Converting errors to TODOs with `warn` and `error` dates that transition the TODO to `warn` after 10 days and `error` after 20 days:
+Converting errors to TODOs with `warn` and `error` dates that transition the `todo` to `warn` after 10 days and `error` after 20 days:
 
 ```bash
 UPDATE_TODO='1' TODO_DAYS_TO_WARN= '10' TODO_DAYS_TO_ERROR='20' eslint . --format @scalvert/eslint-formatter-todo
 ```
 
-Converting errors to TODOs with `warn` and `error` dates that transition the TODO `error` after 20 days, but doesn't include a `warn` date:
+Converting errors to TODOs with `warn` and `error` dates that transition the `todo` `error` after 20 days, but doesn't include a `warn` date:
 
 ```bash
 UPDATE_TODO='1' TODO_DAYS_TO_WARN= '' TODO_DAYS_TO_ERROR='20' eslint . --format @scalvert/eslint-formatter-todo

--- a/__tests__/acceptance/eslint-with-todo-formatter-test.ts
+++ b/__tests__/acceptance/eslint-with-todo-formatter-test.ts
@@ -83,7 +83,6 @@ describe('eslint with todo formatter', function () {
     });
     project.install();
 
-    debugger;
     let result = await runEslintWithFormatter({
       env: { TODO_DAYS_TO_WARN: '10' },
     });
@@ -104,7 +103,6 @@ describe('eslint with todo formatter', function () {
   });
 
   it('with UPDATE_TODO but no todos, outputs todos created summary', async function () {
-    debugger;
     project.write({
       src: {
         'no-problems.js': readFixture('with-no-problems.js'),

--- a/__tests__/acceptance/eslint-with-todo-formatter-test.ts
+++ b/__tests__/acceptance/eslint-with-todo-formatter-test.ts
@@ -404,7 +404,7 @@ describe('eslint with todo formatter', function () {
     });
 
     expect(result.stderr).toMatch(
-      'The provided TODO configuration contains invalid values. The `warn` value (10) must be less than the `error` value (5).'
+      'The provided todo configuration contains invalid values. The `warn` value (10) must be less than the `error` value (5).'
     );
   });
 

--- a/__tests__/acceptance/eslint-with-todo-formatter-test.ts
+++ b/__tests__/acceptance/eslint-with-todo-formatter-test.ts
@@ -280,7 +280,7 @@ describe('eslint with todo formatter', function () {
     });
     project.install();
 
-    // run eslint to generate TODO dir but don't capture the result because this is not what we're testing
+    // run eslint to generate todo dir but don't capture the result because this is not what we're testing
     await runEslintWithFormatter({
       env: { UPDATE_TODO: '1' },
     });

--- a/__tests__/acceptance/eslint-with-todo-formatter-test.ts
+++ b/__tests__/acceptance/eslint-with-todo-formatter-test.ts
@@ -116,10 +116,7 @@ describe('eslint with todo formatter', function () {
     });
 
     expect(result.exitCode).toEqual(0);
-    expect(result.stdout).toMatchInlineSnapshot(`
-      "
-      ✔ 0 todos created, 0 todos removed"
-    `);
+    expect(result.stdout).toMatch(/✔ 0 todos created, 0 todos removed/);
   });
 
   it('with UPDATE_TODO, outputs todos created summary', async () => {
@@ -136,10 +133,7 @@ describe('eslint with todo formatter', function () {
     });
 
     expect(result.exitCode).toEqual(0);
-    expect(result.stdout).toMatchInlineSnapshot(`
-      "
-      ✔ 10 todos created, 0 todos removed"
-    `);
+    expect(result.stdout).toMatch(/✔ 10 todos created, 0 todos removed/);
   });
 
   it('with UPDATE_TODO and INCLUDE_TODO, outputs todos created summary', async () => {
@@ -156,27 +150,13 @@ describe('eslint with todo formatter', function () {
     });
 
     expect(result.exitCode).toEqual(0);
-    expect(result.stdout).toMatchInlineSnapshot(`
-      "
-      /private/var/folders/5m/4ybwhyvn3979lm2223q_q22c000gyd/T/tmp-97343RTHwm6PvOKI/fake-project/src/with-errors-0.js
-         1:10  todo  'addOne' is defined but never used          no-unused-vars
-         2:7   todo  Use the isNaN function to compare with NaN  use-isnan
-         2:9   todo  Expected '!==' and instead saw '!='         eqeqeq
-         3:12  todo  Unary operator '++' used                    no-plusplus
-         3:12  todo  Assignment to function parameter 'i'        no-param-reassign
-         5:3   todo  Function 'addOne' expected a return value   consistent-return
-         5:3   todo  Unnecessary return statement                no-useless-return
-
-      /private/var/folders/5m/4ybwhyvn3979lm2223q_q22c000gyd/T/tmp-97343RTHwm6PvOKI/fake-project/src/with-errors-1.js
-         1:10  todo  'fibonacci' is defined but never used   no-unused-vars
-         8:5   todo  Unary operator '--' used                no-plusplus
-         8:5   todo  Assignment to function parameter 'num'  no-param-reassign
-
-      ✖ 0 problems (0 errors, 0 warnings, 10 todos)
-        0 errors, 0 warnings, and 1 todo potentially fixable with the \`--fix\` option.
-
-      ✔ 10 todos created, 0 todos removed"
-    `);
+    expect(result.stdout).toMatch(
+      /✖ 0 problems \(0 errors, 0 warnings, 10 todos/
+    );
+    expect(result.stdout).toMatch(
+      /0 errors, 0 warnings, and 1 todo potentially fixable with the `--fix` option./
+    );
+    expect(result.stdout).toMatch(/✔ 10 todos created, 0 todos removed/);
   });
 
   it('with UPDATE_TODO, outputs todos created summary with warn info', async () => {
@@ -193,10 +173,9 @@ describe('eslint with todo formatter', function () {
     });
 
     expect(result.exitCode).toEqual(0);
-    expect(result.stdout).toMatchInlineSnapshot(`
-      "
-      ✔ 10 todos created, 0 todos removed (warn after 10 days)"
-    `);
+    expect(result.stdout).toMatch(
+      /✔ 10 todos created, 0 todos removed \(warn after 10 days\)/
+    );
   });
 
   it('with UPDATE_TODO, outputs todos created summary with error info', async () => {
@@ -213,10 +192,9 @@ describe('eslint with todo formatter', function () {
     });
 
     expect(result.exitCode).toEqual(0);
-    expect(result.stdout).toMatchInlineSnapshot(`
-      "
-      ✔ 10 todos created, 0 todos removed (error after 10 days)"
-    `);
+    expect(result.stdout).toMatch(
+      /✔ 10 todos created, 0 todos removed \(error after 10 days\)/
+    );
   });
 
   it('with UPDATE_TODO, outputs todos created summary with warn and error info', async () => {
@@ -237,10 +215,9 @@ describe('eslint with todo formatter', function () {
     });
 
     expect(result.exitCode).toEqual(0);
-    expect(result.stdout).toMatchInlineSnapshot(`
-      "
-      ✔ 10 todos created, 0 todos removed (warn after 5, error after 10 days)"
-    `);
+    expect(result.stdout).toMatch(
+      /✔ 10 todos created, 0 todos removed \(warn after 5, error after 10 days\)/
+    );
   });
 
   it('should emit errors and warnings as normal', async () => {

--- a/__tests__/acceptance/eslint-with-todo-formatter-test.ts
+++ b/__tests__/acceptance/eslint-with-todo-formatter-test.ts
@@ -58,7 +58,7 @@ describe('eslint with todo formatter', function () {
   });
 
   afterEach(() => {
-    // project.dispose();
+    project.dispose();
   });
 
   it('should not emit anything when there are no errors or warnings', async () => {

--- a/__tests__/unit/format-test.ts
+++ b/__tests__/unit/format-test.ts
@@ -6,7 +6,15 @@ describe('format', () => {
   it('should return all errors', async () => {
     const results = fixtures.eslintWithErrors('/stable/path');
 
-    expect(stripAnsi(format(results))).toMatchInlineSnapshot(`
+    expect(
+      stripAnsi(
+        format(results, {
+          updateTodo: false,
+          includeTodo: false,
+          todoInfo: undefined,
+        })
+      )
+    ).toMatchInlineSnapshot(`
       "
       /stable/path/app/controllers/settings.js
          25:21  error  Do not access Object.prototype method 'hasOwnProperty' from target object  no-prototype-builtins
@@ -48,14 +56,29 @@ describe('format', () => {
   it('should not return anything when includeTodo is false and there are only todo items', async () => {
     const results = fixtures.eslintWithTodos('/stable/path');
 
-    expect(stripAnsi(format(results)).trim()).toEqual('');
+    expect(
+      stripAnsi(
+        format(results, {
+          updateTodo: false,
+          includeTodo: false,
+          todoInfo: undefined,
+        })
+      ).trim()
+    ).toEqual('');
   });
 
   it('should return all todo items when includeTodo is true', async () => {
     const results = fixtures.eslintWithTodos('/stable/path');
 
-    expect(stripAnsi(format(results, { includeTodo: true })))
-      .toMatchInlineSnapshot(`
+    expect(
+      stripAnsi(
+        format(results, {
+          updateTodo: false,
+          includeTodo: true,
+          todoInfo: undefined,
+        })
+      )
+    ).toMatchInlineSnapshot(`
       "
       /stable/path/app/controllers/settings.js
          25:21  todo  Do not access Object.prototype method 'hasOwnProperty' from target object  no-prototype-builtins
@@ -97,7 +120,15 @@ describe('format', () => {
   it('should only return errors and warnings if includeTodo is false and there are errors, warnings, and todo items', async () => {
     const results = fixtures.eslintWithErrorsWarningsTodos('/stable/path');
 
-    expect(stripAnsi(format(results))).toMatchInlineSnapshot(`
+    expect(
+      stripAnsi(
+        format(results, {
+          updateTodo: false,
+          includeTodo: false,
+          todoInfo: undefined,
+        })
+      )
+    ).toMatchInlineSnapshot(`
       "
       /stable/path/app/errors-only.js
          25:21  error  Do not access Object.prototype method 'hasOwnProperty' from target object  no-prototype-builtins

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "jest --no-cache"
   },
   "dependencies": {
-    "@ember-template-lint/todo-utils": "^6.0.0",
+    "@ember-template-lint/todo-utils": "^6.0.1",
     "chalk": "^4.1.0",
     "eslint": "^7.10.0",
     "fs-extra": "^9.0.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "jest --no-cache"
   },
   "dependencies": {
-    "@ember-template-lint/todo-utils": "^5.0.0",
+    "@ember-template-lint/todo-utils": "^6.0.0",
     "chalk": "^4.1.0",
     "eslint": "^7.10.0",
     "fs-extra": "^9.0.1",

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -33,7 +33,7 @@ export function formatter(results: ESLint.LintResult[]): string {
       'Using `TODO_DAYS_TO_WARN` or `TODO_DAYS_TO_ERROR` is only valid when the `UPDATE_TODO` environment variable is being used.'
     );
   }
-  debugger;
+
   if (updateTodo) {
     const todoConfig = getTodoConfig(process.cwd());
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -15,8 +15,18 @@ export type TodoResultMessage = Omit<Linter.LintMessage, 'severity'> & {
   severity: Linter.Severity | -1;
 };
 
+export type TodoInfo =
+  | {
+      added: number;
+      removed: number;
+      todoConfig: TodoConfig | undefined;
+    }
+  | undefined;
+
 export interface TodoFormatterOptions {
+  updateTodo: boolean;
   includeTodo: boolean;
+  todoInfo: TodoInfo;
 }
 
 export interface TodoFormatterCounts {

--- a/yarn.lock
+++ b/yarn.lock
@@ -278,14 +278,15 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@ember-template-lint/todo-utils@^6.0.0":
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/@ember-template-lint/todo-utils/-/todo-utils-6.0.0.tgz#0d9ad05c6381ef0b66bac5f389891b73a6a8d5c6"
-  integrity sha512-QGrrucBZCHcRwfwEBQEfn8AMwxkCHiP2kBwrpC4UovHlPUR2z/vh86WFb9wAJMsZgoDcT1ZrURJGGVDszWB5XA==
+"@ember-template-lint/todo-utils@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@ember-template-lint/todo-utils/-/todo-utils-6.0.1.tgz#abe4916652b8e052ffc405dad8e265f098b0cb99"
+  integrity sha512-EAZ/9BQoWNcsX3mwpdxqtwNyHskTtpdImE/gEFrzDFfCK0Tho83V3j0ZdPGiW4TEXFP5yFcxOxy1ZQPL+En/5w==
   dependencies:
-    "@types/eslint" "^7.2.3"
+    "@types/eslint" "^7.2.6"
     fs-extra "^9.0.1"
     slash "^3.0.0"
+    tslib "^2.1.0"
 
 "@eslint/eslintrc@^0.2.2":
   version "0.2.2"
@@ -704,7 +705,7 @@
     "@types/node" "*"
     "@types/responselike" "*"
 
-"@types/eslint@^7.2.3", "@types/eslint@^7.2.4":
+"@types/eslint@^7.2.4", "@types/eslint@^7.2.6":
   version "7.2.6"
   resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-7.2.6.tgz#5e9aff555a975596c03a98b59ecd103decc70c3c"
   integrity sha512-I+1sYH+NPQ3/tVqCeUSBwTE/0heyvtXqpIopUUArlBm0Kpocb8FbMa3AZ/ASKIFpN3rnEx932TTXDbt9OXsNDw==
@@ -5780,6 +5781,11 @@ tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
+  integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
 
 tsutils@^3.17.1:
   version "3.17.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -278,10 +278,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@ember-template-lint/todo-utils@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@ember-template-lint/todo-utils/-/todo-utils-5.0.0.tgz#f2f71c75a09c815e2e86719844431f8f639f6edb"
-  integrity sha512-lho61ryxiPst56YTmtLKk3BqpFaVU/vtueTFkOhdXwT4/0zgO/AbzgBRd/Pvfcur8v4+Wr4VY3jtdIS6s3otug==
+"@ember-template-lint/todo-utils@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@ember-template-lint/todo-utils/-/todo-utils-6.0.0.tgz#0d9ad05c6381ef0b66bac5f389891b73a6a8d5c6"
+  integrity sha512-QGrrucBZCHcRwfwEBQEfn8AMwxkCHiP2kBwrpC4UovHlPUR2z/vh86WFb9wAJMsZgoDcT1ZrURJGGVDszWB5XA==
   dependencies:
     "@types/eslint" "^7.2.3"
     fs-extra "^9.0.1"
@@ -913,14 +913,6 @@
     "@typescript-eslint/typescript-estree" "4.13.0"
     debug "^4.1.1"
 
-"@typescript-eslint/scope-manager@4.12.0":
-  version "4.12.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.12.0.tgz#beeb8beca895a07b10c593185a5612f1085ef279"
-  integrity sha512-QVf9oCSVLte/8jvOsxmgBdOaoe2J0wtEmBr13Yz0rkBNkl5D8bfnf6G4Vhox9qqMIoG7QQoVwd2eG9DM/ge4Qg==
-  dependencies:
-    "@typescript-eslint/types" "4.12.0"
-    "@typescript-eslint/visitor-keys" "4.12.0"
-
 "@typescript-eslint/scope-manager@4.13.0":
   version "4.13.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.13.0.tgz#5b45912a9aa26b29603d8fa28f5e09088b947141"
@@ -929,29 +921,10 @@
     "@typescript-eslint/types" "4.13.0"
     "@typescript-eslint/visitor-keys" "4.13.0"
 
-"@typescript-eslint/types@4.12.0":
-  version "4.12.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.12.0.tgz#fb891fe7ccc9ea8b2bbd2780e36da45d0dc055e5"
-  integrity sha512-N2RhGeheVLGtyy+CxRmxdsniB7sMSCfsnbh8K/+RUIXYYq3Ub5+sukRCjVE80QerrUBvuEvs4fDhz5AW/pcL6g==
-
 "@typescript-eslint/types@4.13.0":
   version "4.13.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.13.0.tgz#6a7c6015a59a08fbd70daa8c83dfff86250502f8"
   integrity sha512-/+aPaq163oX+ObOG00M0t9tKkOgdv9lq0IQv/y4SqGkAXmhFmCfgsELV7kOCTb2vVU5VOmVwXBXJTDr353C1rQ==
-
-"@typescript-eslint/typescript-estree@4.12.0":
-  version "4.12.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.12.0.tgz#3963418c850f564bdab3882ae23795d115d6d32e"
-  integrity sha512-gZkFcmmp/CnzqD2RKMich2/FjBTsYopjiwJCroxqHZIY11IIoN0l5lKqcgoAPKHt33H2mAkSfvzj8i44Jm7F4w==
-  dependencies:
-    "@typescript-eslint/types" "4.12.0"
-    "@typescript-eslint/visitor-keys" "4.12.0"
-    debug "^4.1.1"
-    globby "^11.0.1"
-    is-glob "^4.0.1"
-    lodash "^4.17.15"
-    semver "^7.3.2"
-    tsutils "^3.17.1"
 
 "@typescript-eslint/typescript-estree@4.13.0":
   version "4.13.0"
@@ -966,14 +939,6 @@
     lodash "^4.17.15"
     semver "^7.3.2"
     tsutils "^3.17.1"
-
-"@typescript-eslint/visitor-keys@4.12.0":
-  version "4.12.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.12.0.tgz#a470a79be6958075fa91c725371a83baf428a67a"
-  integrity sha512-hVpsLARbDh4B9TKYz5cLbcdMIOAoBYgFPCSP9FFS/liSF+b33gVNq8JHY3QGhHNVz85hObvL7BEYLlgx553WCw==
-  dependencies:
-    "@typescript-eslint/types" "4.12.0"
-    eslint-visitor-keys "^2.0.0"
 
 "@typescript-eslint/visitor-keys@4.13.0":
   version "4.13.0"


### PR DESCRIPTION
Resolves #66 

When using `TODO_DAYS_TO_WARN` or `TODO_DAYS_TO_ERROR` without `UPDATE_TODO`, it prints the following error:

You must use `UPDATE_TODO` when using any of `TODO_DAYS_TO_WARN` or `TODO_DAYS_TO_ERROR`.
When new todos are created:

```shell
✔ 1 todos created
```

When new todo created with warn days:

```shell
✔ 1 todos created (warn after 10 days)
```

When new todo created with error days:

```shell
✔ 1 todos created (error after 10 days)
```

When new todo created with warn and error days:

```shell
✔ 1 todos created (warn after 5 and error after 10 days)
```