### PR TITLE
Adds CLEAN_TODO env var to match ember-template-lint implementation

### DIFF
--- a/__tests__/acceptance/eslint-with-todo-formatter-test.ts
+++ b/__tests__/acceptance/eslint-with-todo-formatter-test.ts
@@ -154,7 +154,7 @@ describe('eslint with todo formatter', function () {
         'with-errors-1.js': getStringFixture('with-errors-1.js'),
       },
     });
-    debugger;
+
     const result = await runEslintWithFormatter({
       env: { UPDATE_TODO: '1' },
     });
@@ -443,7 +443,7 @@ describe('eslint with todo formatter', function () {
     expect(stdout).toMatch(/✖ 3 problems \(2 errors, 1 warning, 7 todos\)/);
   });
 
-  it('errors if a todo item is no longer valid when running without params', async function () {
+  it('errors if a todo item is no longer valid when running without params, and fixes with --fix', async function () {
     project.write({
       src: {
         'with-fixable-error.js': getStringFixture('with-fixable-error.js'),
@@ -469,12 +469,57 @@ describe('eslint with todo formatter', function () {
     const results = stripAnsi(result.stdout).trim().split(/\r?\n/);
 
     expect(results[1]).toMatch(
-      /0:0  error  Todo violation passes `no-unused-vars` rule. Please run `--fix` to remove this todo from the todo list  invalid-todo-violation-rule/
+      /0:0  error  Todo violation passes `no-unused-vars` rule. Please run with `CLEAN_TODO=1` env var to remove this todo from the todo list  invalid-todo-violation-rule/
     );
     expect(results[3]).toMatch(/✖ 1 problem \(1 error, 0 warnings\)/);
 
     // run fix, and expect that this will delete the outstanding todo item
     await runEslintWithFormatter(['--fix']);
+
+    // run normally again and expect no error
+    result = await runEslintWithFormatter();
+
+    const todoDirs = readdirSync(getTodoStorageDirPath(project.baseDir));
+
+    expect(result.exitCode).toEqual(0);
+    expect(stripAnsi(result.stdout).trim()).toEqual('');
+    expect(todoDirs).toHaveLength(0);
+  });
+
+  it('errors if a todo item is no longer valid when running without params, and fixes with CLEAN_TODO=1', async function () {
+    project.write({
+      src: {
+        'with-fixable-error.js': getStringFixture('with-fixable-error.js'),
+      },
+    });
+
+    // generate todo based on existing error
+    await runEslintWithFormatter({
+      env: { UPDATE_TODO: '1' },
+    });
+
+    // mimic fixing the error manually via user interaction
+    project.write({
+      src: {
+        'with-fixable-error.js': getStringFixture('no-errors.js'),
+      },
+    });
+
+    // run normally and expect an error for not running --fix
+    let result = await runEslintWithFormatter();
+
+    expect(result.exitCode).toEqual(1);
+    const results = stripAnsi(result.stdout).trim().split(/\r?\n/);
+
+    expect(results[1]).toMatch(
+      /0:0  error  Todo violation passes `no-unused-vars` rule. Please run with `CLEAN_TODO=1` env var to remove this todo from the todo list  invalid-todo-violation-rule/
+    );
+    expect(results[3]).toMatch(/✖ 1 problem \(1 error, 0 warnings\)/);
+
+    // run fix, and expect that this will delete the outstanding todo item
+    await runEslintWithFormatter({
+      env: { CLEAN_TODO: '1' },
+    });
 
     // run normally again and expect no error
     result = await runEslintWithFormatter();

--- a/__tests__/unit/print-results-test.ts
+++ b/__tests__/unit/print-results-test.ts
@@ -11,6 +11,8 @@ describe('print-results', () => {
         printResults(results, {
           updateTodo: false,
           includeTodo: false,
+          cleanTodo: false,
+          shouldFix: false,
           todoInfo: undefined,
           writeTodoOptions: {},
         })
@@ -62,6 +64,8 @@ describe('print-results', () => {
         printResults(results, {
           updateTodo: false,
           includeTodo: false,
+          cleanTodo: false,
+          shouldFix: false,
           todoInfo: undefined,
           writeTodoOptions: {},
         })
@@ -77,6 +81,8 @@ describe('print-results', () => {
         printResults(results, {
           updateTodo: false,
           includeTodo: true,
+          cleanTodo: false,
+          shouldFix: false,
           todoInfo: undefined,
           writeTodoOptions: {},
         })
@@ -128,6 +134,8 @@ describe('print-results', () => {
         printResults(results, {
           updateTodo: false,
           includeTodo: false,
+          cleanTodo: false,
+          shouldFix: false,
           todoInfo: undefined,
           writeTodoOptions: {},
         })

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -41,10 +41,12 @@ export function formatter(results: ESLint.LintResult[]): string {
   };
   const updateTodo = process.env.UPDATE_TODO === '1';
   const includeTodo = process.env.INCLUDE_TODO === '1';
+  const cleanTodo = process.env.CLEAN_TODO == '1';
+  const shouldFix = hasFlag('fix');
   const writeTodoOptions: Partial<WriteTodoOptions> = {
     shouldRemove: (todoDatum: TodoData) => todoDatum.engine === 'eslint',
   };
-  debugger;
+
   if (
     (process.env.TODO_DAYS_TO_WARN || process.env.TODO_DAYS_TO_ERROR) &&
     !updateTodo
@@ -81,6 +83,8 @@ export function formatter(results: ESLint.LintResult[]): string {
     processResults(results, maybeTodos, {
       updateTodo,
       includeTodo,
+      cleanTodo,
+      shouldFix,
       todoInfo,
       writeTodoOptions: optionsForFile,
     });
@@ -89,6 +93,8 @@ export function formatter(results: ESLint.LintResult[]): string {
   return printResults(results, {
     updateTodo,
     includeTodo,
+    cleanTodo,
+    shouldFix,
     todoInfo,
     writeTodoOptions,
   });
@@ -170,7 +176,7 @@ function processResults(
     );
 
     if (remove.size > 0 || expired.size > 0) {
-      if (hasFlag('fix')) {
+      if (options.shouldFix || options.cleanTodo) {
         applyTodoChanges(
           getTodoStorageDirPath(baseDir),
           new Map(),
@@ -272,7 +278,7 @@ function pushResult(results: ESLint.LintResult[], todo: TodoData) {
 
   const result: Linter.LintMessage = {
     ruleId: 'invalid-todo-violation-rule',
-    message: `Todo violation passes \`${todo.ruleId}\` rule. Please run \`--fix\` to remove this todo from the todo list.`,
+    message: `Todo violation passes \`${todo.ruleId}\` rule. Please run with \`CLEAN_TODO=1\` env var to remove this todo from the todo list.`,
     severity: 2,
     column: 0,
     line: 0,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -28,6 +28,8 @@ export type TodoInfo =
 export interface TodoFormatterOptions {
   updateTodo: boolean;
   includeTodo: boolean;
+  cleanTodo: boolean;
+  shouldFix: boolean;
   todoInfo: TodoInfo;
   writeTodoOptions: Partial<WriteTodoOptions>;
 }


### PR DESCRIPTION
Adds capability of using `CLEAN_TODO=1` in addition to `--fix` to clean outstanding todos. This will ease the migration to auto-clean todos.