### PR TITLE
Enable auto-fix of todos

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,17 @@ If you want to see todos as part of `eslint`'s output, you can include them
 
 <img src="docs/post-todo.png" style="background-color: #fff" />
 
-If an error is fixed manually, `eslint` will let you know that there's an outstanding `todo` file. You can remove this file by running `--fix`
+If an error is fixed manually, `eslint` will automatically remove the todo when run again.
 
 ```bash
-eslint . --format @scalvert/eslint-formatter-todo --fix
+eslint . --format @scalvert/eslint-formatter-todo
+```
+
+If you want to opt out of this behavior, you can run with the `NO_CLEAN_TODO` env var set.
+
+```bash
+# Will not remove the todo automatically
+NO_CLEAN_TODO='1' eslint . --format @scalvert/eslint-formatter-todo
 ```
 
 ### Configuring Due Dates

--- a/__tests__/__utils__/setup-env-var.ts
+++ b/__tests__/__utils__/setup-env-var.ts
@@ -1,0 +1,22 @@
+export function setupEnvVar(name: string, value: string): void {
+  let oldValue: string | undefined | null;
+
+  beforeEach(function () {
+    // eslint-disable-next-line unicorn/no-null
+    oldValue = name in process.env ? process.env[name] : null;
+
+    if (value === null) {
+      delete process.env[name];
+    } else {
+      process.env[name] = value;
+    }
+  });
+
+  afterEach(function () {
+    if (oldValue === null) {
+      delete process.env[name];
+    } else {
+      process.env[name] = oldValue;
+    }
+  });
+}

--- a/__tests__/acceptance/eslint-with-todo-formatter-test.ts
+++ b/__tests__/acceptance/eslint-with-todo-formatter-test.ts
@@ -488,48 +488,6 @@ describe('eslint with todo formatter', function () {
     expect(todoDirs).toHaveLength(0);
   });
 
-  it('errors if a todo item is no longer valid when running without params, and fixes when run again', async function () {
-    project.write({
-      src: {
-        'with-fixable-error.js': getStringFixture('with-fixable-error.js'),
-      },
-    });
-
-    // generate todo based on existing error
-    await runEslintWithFormatter({
-      env: { UPDATE_TODO: '1' },
-    });
-
-    // mimic fixing the error manually via user interaction
-    project.write({
-      src: {
-        'with-fixable-error.js': getStringFixture('no-errors.js'),
-      },
-    });
-
-    // run normally and expect an error for not running --fix
-    let result = await runEslintWithFormatter({
-      env: { CI: '1' },
-    });
-
-    expect(result.exitCode).toEqual(1);
-    const results = stripAnsi(result.stdout).trim().split(/\r?\n/);
-
-    expect(results[1]).toMatch(
-      /0:0  error  Todo violation passes `no-unused-vars` rule. Please run with `CLEAN_TODO=1` env var to remove this todo from the todo list  invalid-todo-violation-rule/
-    );
-    expect(results[3]).toMatch(/✖ 1 problem \(1 error, 0 warnings\)/);
-
-    // run normally again and expect no error
-    result = await runEslintWithFormatter();
-
-    const todoDirs = readdirSync(getTodoStorageDirPath(project.baseDir));
-
-    expect(result.exitCode).toEqual(0);
-    expect(stripAnsi(result.stdout).trim()).toEqual('');
-    expect(todoDirs).toHaveLength(0);
-  });
-
   for (const { name, isLegacy, setTodoConfig } of [
     {
       name: 'Shorthand todo configuration',

--- a/__tests__/acceptance/eslint-with-todo-formatter-test.ts
+++ b/__tests__/acceptance/eslint-with-todo-formatter-test.ts
@@ -463,7 +463,9 @@ describe('eslint with todo formatter', function () {
     });
 
     // run normally and expect an error for not running --fix
-    let result = await runEslintWithFormatter();
+    let result = await runEslintWithFormatter({
+      env: { CI: '1' },
+    });
 
     expect(result.exitCode).toEqual(1);
     const results = stripAnsi(result.stdout).trim().split(/\r?\n/);
@@ -486,7 +488,7 @@ describe('eslint with todo formatter', function () {
     expect(todoDirs).toHaveLength(0);
   });
 
-  it('errors if a todo item is no longer valid when running without params, and fixes with CLEAN_TODO=1', async function () {
+  it('errors if a todo item is no longer valid when running without params, and fixes when run again', async function () {
     project.write({
       src: {
         'with-fixable-error.js': getStringFixture('with-fixable-error.js'),
@@ -506,7 +508,9 @@ describe('eslint with todo formatter', function () {
     });
 
     // run normally and expect an error for not running --fix
-    let result = await runEslintWithFormatter();
+    let result = await runEslintWithFormatter({
+      env: { CI: '1' },
+    });
 
     expect(result.exitCode).toEqual(1);
     const results = stripAnsi(result.stdout).trim().split(/\r?\n/);
@@ -515,11 +519,6 @@ describe('eslint with todo formatter', function () {
       /0:0  error  Todo violation passes `no-unused-vars` rule. Please run with `CLEAN_TODO=1` env var to remove this todo from the todo list  invalid-todo-violation-rule/
     );
     expect(results[3]).toMatch(/✖ 1 problem \(1 error, 0 warnings\)/);
-
-    // run fix, and expect that this will delete the outstanding todo item
-    await runEslintWithFormatter({
-      env: { CLEAN_TODO: '1' },
-    });
 
     // run normally again and expect no error
     result = await runEslintWithFormatter();

--- a/__tests__/unit/print-results-test.ts
+++ b/__tests__/unit/print-results-test.ts
@@ -8,8 +8,7 @@ function getOptions(options = {}) {
     {
       updateTodo: false,
       includeTodo: false,
-      cleanTodo: false,
-      shouldFix: false,
+      shouldCleanTodos: true,
       todoInfo: undefined,
       writeTodoOptions: {},
     },

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@ember-template-lint/todo-utils": "^10.0.0",
     "chalk": "^4.1.0",
+    "ci-info": "^3.3.0",
     "eslint": "^7.10.0",
     "fs-extra": "^10.0.0",
     "has-flag": "^4.0.0",

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -34,7 +34,7 @@ export function formatter(results: ESLint.LintResult[]): string {
   if (!todoConfigResult.isValid) {
     throw new Error(todoConfigResult.message);
   }
-
+  debugger;
   const todoInfo = {
     added: 0,
     removed: 0,
@@ -42,7 +42,7 @@ export function formatter(results: ESLint.LintResult[]): string {
   };
   const updateTodo = process.env.UPDATE_TODO === '1';
   const includeTodo = process.env.INCLUDE_TODO === '1';
-  const cleanTodo = process.env.NO_CLEAN_TODO !== '1' && !ci.isCI;
+  const cleanTodo = !process.env.NO_CLEAN_TODO && !ci.isCI;
   const shouldFix = hasFlag('fix');
   const shouldCleanTodos = shouldFix || cleanTodo;
   const writeTodoOptions: Partial<WriteTodoOptions> = {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -28,8 +28,7 @@ export type TodoInfo =
 export interface TodoFormatterOptions {
   updateTodo: boolean;
   includeTodo: boolean;
-  cleanTodo: boolean;
-  shouldFix: boolean;
+  shouldCleanTodos: boolean;
   todoInfo: TodoInfo;
   writeTodoOptions: Partial<WriteTodoOptions>;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1649,6 +1649,11 @@ ci-info@^3.1.1:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.1.1.tgz#9a32fcefdf7bcdb6f0a7e1c0f8098ec57897b80a"
   integrity sha512-kdRWLBIJwdsYJWYJFtAFFYxybguqeF91qpZaggjG5Nf8QKdizFG2hjqvaTXbxFIcYbSaD74KpAXv6BSm17DHEQ==
 
+ci-info@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.3.0.tgz#b4ed1fb6818dea4803a55c623041f9165d2066b2"
+  integrity sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==
+
 cjs-module-lexer@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-0.6.0.tgz#4186fcca0eae175970aee870b9fe2d6cf8d5655f"


### PR DESCRIPTION
Requiring users to explicitly call `CLEAN_TODO` or `--fix` after pushing an artificial error in our results causes the following:

- a mismatched count of actual errors vs. artificial errors from todos that need cleaning
- extra work for the user to clean the todos when they really just want them cleaned

In light of this, we've inversed the functionality, so that the process of cleaning todos is the default, and you can opt out by using `NO_CLEAN_TODO`.