### PR TITLE
Convert to single file storage

### DIFF
--- a/__tests__/acceptance/eslint-with-todo-formatter-test.ts
+++ b/__tests__/acceptance/eslint-with-todo-formatter-test.ts
@@ -466,7 +466,10 @@ describe('eslint with todo formatter', function () {
     let result = await runEslintWithFormatter({
       env: { CI: '1' },
     });
+    });
 
+      env: { CI: '1' },
+    });
     expect(result.exitCode).toEqual(1);
     const results = stripAnsi(result.stdout).trim().split(/\r?\n/);
 
@@ -475,9 +478,7 @@ describe('eslint with todo formatter', function () {
     );
     expect(results[3]).toMatch(/✖ 1 problem \(1 error, 0 warnings\)/);
 
-    // run fix, and expect that this will delete the outstanding todo item
     await runEslintWithFormatter(['--fix']);
-
     // run normally again and expect no error
     result = await runEslintWithFormatter();
 

--- a/__tests__/acceptance/eslint-with-todo-formatter-test.ts
+++ b/__tests__/acceptance/eslint-with-todo-formatter-test.ts
@@ -1,13 +1,13 @@
 import execa from 'execa';
 import stripAnsi from 'strip-ansi';
 import { differenceInDays, subDays } from 'date-fns';
-import { readdirSync } from 'fs-extra';
 import {
   DaysToDecay,
   DaysToDecayByRule,
-  getTodoStorageDirPath,
+  getTodoStorageFilePath,
   readTodoData,
-  todoStorageDirExists,
+  readTodoStorageFile,
+  todoStorageFileExists,
   writeTodos,
 } from '@ember-template-lint/todo-utils';
 import { FakeProject } from '../__utils__/fake-project';
@@ -283,8 +283,8 @@ describe('eslint with todo formatter', function () {
     });
 
     expect(result.exitCode).toEqual(0);
-    expect(todoStorageDirExists(project.baseDir)).toEqual(true);
-    expect(readTodoData(project.baseDir)).toHaveLength(7);
+    expect(todoStorageFileExists(project.baseDir)).toEqual(true);
+    expect(readTodoData(project.baseDir).size).toEqual(7);
 
     result = await runEslintWithFormatter();
 
@@ -305,8 +305,8 @@ describe('eslint with todo formatter', function () {
     });
 
     expect(result.exitCode).toEqual(0);
-    expect(todoStorageDirExists(project.baseDir)).toEqual(true);
-    expect(readTodoData(project.baseDir)).toHaveLength(7);
+    expect(todoStorageFileExists(project.baseDir)).toEqual(true);
+    expect(readTodoData(project.baseDir).size).toEqual(7);
 
     project.write({
       src: {
@@ -466,6 +466,8 @@ describe('eslint with todo formatter', function () {
     let result = await runEslintWithFormatter({
       env: { CI: '1' },
     });
+      getTodoStorageFilePath(project.baseDir)
+    );
     });
 
       env: { CI: '1' },
@@ -482,11 +484,13 @@ describe('eslint with todo formatter', function () {
     // run normally again and expect no error
     result = await runEslintWithFormatter();
 
-    const todoDirs = readdirSync(getTodoStorageDirPath(project.baseDir));
+    const todoContents = readTodoStorageFile(
+      getTodoStorageFilePath(project.baseDir)
+    );
 
     expect(result.exitCode).toEqual(0);
     expect(stripAnsi(result.stdout).trim()).toEqual('');
-    expect(todoDirs).toHaveLength(0);
+    expect(todoContents).toHaveLength(2);
   });
 
   for (const { name, isLegacy, setTodoConfig } of [

--- a/__tests__/acceptance/eslint-with-todo-formatter-test.ts.orig
+++ b/__tests__/acceptance/eslint-with-todo-formatter-test.ts.orig
@@ -466,6 +466,8 @@ describe('eslint with todo formatter', function () {
     let result = await runEslintWithFormatter({
       env: { CI: '1' },
     });
+<<<<<<< HEAD
+=======
 
     expect(result.exitCode).toEqual(1);
     const results = stripAnsi(result.stdout).trim().split(/\r?\n/);
@@ -478,6 +480,37 @@ describe('eslint with todo formatter', function () {
     // run fix, and expect that this will delete the outstanding todo item
     await runEslintWithFormatter(['--fix']);
 
+    // run normally again and expect no error
+    result = await runEslintWithFormatter();
+
+    const todoContents = readTodoStorageFile(
+      getTodoStorageFilePath(project.baseDir)
+    );
+
+    expect(result.exitCode).toEqual(0);
+    expect(stripAnsi(result.stdout).trim()).toEqual('');
+    expect(todoContents).toHaveLength(2);
+  });
+
+  it('errors if a todo item is no longer valid when running without params, and fixes when run again', async function () {
+    project.write({
+      src: {
+        'with-fixable-error.js': getStringFixture('with-fixable-error.js'),
+      },
+>>>>>>> 83e6a3d (breaking: Convert to single file storage)
+    });
+
+      env: { CI: '1' },
+    });
+    expect(result.exitCode).toEqual(1);
+    const results = stripAnsi(result.stdout).trim().split(/\r?\n/);
+
+    expect(results[1]).toMatch(
+      /0:0  error  Todo violation passes `no-unused-vars` rule. Please run with `CLEAN_TODO=1` env var to remove this todo from the todo list  invalid-todo-violation-rule/
+    );
+    expect(results[3]).toMatch(/✖ 1 problem \(1 error, 0 warnings\)/);
+
+    await runEslintWithFormatter(['--fix']);
     // run normally again and expect no error
     result = await runEslintWithFormatter();
 

--- a/__tests__/unit/formatter-test.ts
+++ b/__tests__/unit/formatter-test.ts
@@ -1,11 +1,8 @@
 import {
-  getTodoStorageDirPath,
   readTodoData,
-  todoFilePathFor,
-  todoStorageDirExists,
+  todoStorageFileExists,
   Severity,
 } from '@ember-template-lint/todo-utils';
-import { existsSync } from 'fs';
 import { DirResult, dirSync } from 'tmp';
 import { buildMaybeTodos, formatter, updateResults } from '../../src/formatter';
 import fixtures from '../__fixtures__/fixtures';
@@ -35,8 +32,7 @@ describe('format-results', () => {
 
     formatter(results);
 
-    const todoDir = getTodoStorageDirPath(tmpDir.name);
-    expect(existsSync(todoDir)).toBe(false);
+    expect(todoStorageFileExists(tmpDir.name)).toBe(false);
   });
 
   it('SHOULD generate a TODO dir with todo files when UPDATE_TODO is set to 1', () => {
@@ -46,11 +42,11 @@ describe('format-results', () => {
 
     formatter(results);
 
-    expect(todoStorageDirExists(tmpDir.name)).toBe(true);
+    expect(todoStorageFileExists(tmpDir.name)).toBe(true);
 
     const todos = readTodoData(tmpDir.name);
 
-    expect(todos).toHaveLength(18);
+    expect(todos.size).toEqual(18);
   });
 
   it('SHOULD not mutate errors if a todo dir is not present', () => {
@@ -81,12 +77,7 @@ describe('format-results', () => {
     // build todo map but without the last result in the results array (so they differ)
     const todoResults = [...results];
     const lastResult = todoResults.pop();
-    const todos = new Map(
-      [...buildMaybeTodos(tmpDir.name, todoResults)].map((todoDatum) => [
-        todoFilePathFor(todoDatum),
-        todoDatum,
-      ])
-    );
+    const todos = buildMaybeTodos(tmpDir.name, todoResults);
 
     updateResults(results, todos);
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:jest": "yarn build && jest --no-cache"
   },
   "dependencies": {
-    "@ember-template-lint/todo-utils": "^10.0.0",
+    "@ember-template-lint/todo-utils": "11.0.0-beta.1",
     "chalk": "^4.1.0",
     "ci-info": "^3.3.0",
     "eslint": "^7.10.0",

--- a/src/formatter.ts.orig
+++ b/src/formatter.ts.orig
@@ -1,0 +1,313 @@
+import {
+  applyTodoChanges,
+  getSeverity,
+  getTodoBatches,
+  getTodoConfig,
+  getTodoStorageDirPath,
+  TodoData,
+  TodoDataV2,
+  todoStorageDirExists,
+  WriteTodoOptions,
+  writeTodos,
+  buildTodoDatum,
+  validateConfig,
+  Severity,
+  TodoConfig,
+  Range,
+  readTodosForFilePath,
+} from '@ember-template-lint/todo-utils';
+import { relative, join } from 'path';
+import hasFlag from 'has-flag';
+import ci from 'ci-info';
+import { printResults } from './print-results';
+import { getBaseDir } from './get-base-dir';
+
+import type { ESLint, Linter } from 'eslint';
+import type { TodoFormatterOptions } from './types';
+
+const LINES_PATTERN = /(.*?(?:\r\n?|\n|$))/gm;
+
+export function formatter(results: ESLint.LintResult[]): string {
+  const baseDir = getBaseDir();
+  const todoConfigResult = validateConfig(baseDir);
+
+  if (!todoConfigResult.isValid) {
+    throw new Error(todoConfigResult.message);
+  }
+  debugger;
+  const todoInfo = {
+    added: 0,
+    removed: 0,
+    todoConfig: getTodoConfig(process.cwd(), 'eslint') ?? {},
+  };
+  const updateTodo = process.env.UPDATE_TODO === '1';
+  const includeTodo = process.env.INCLUDE_TODO === '1';
+<<<<<<< HEAD
+  const cleanTodo = !process.env.NO_CLEAN_TODO && !ci.isCI;
+=======
+  const cleanTodo = process.env.NO_CLEAN_TODO !== '1' && !ci.isCI;
+>>>>>>> 97122fd (feat: Enable auto-fix of todos)
+  const shouldFix = hasFlag('fix');
+  const shouldCleanTodos = shouldFix || cleanTodo;
+  const writeTodoOptions: Partial<WriteTodoOptions> = {
+    shouldRemove: (todoDatum: TodoData) => todoDatum.engine === 'eslint',
+  };
+
+  if (
+    (process.env.TODO_DAYS_TO_WARN || process.env.TODO_DAYS_TO_ERROR) &&
+    !updateTodo
+  ) {
+    throw new Error(
+      'Using `TODO_DAYS_TO_WARN` or `TODO_DAYS_TO_ERROR` is only valid when the `UPDATE_TODO` environment variable is being used.'
+    );
+  }
+
+  for (const fileResults of results) {
+    const maybeTodos = buildMaybeTodos(
+      baseDir,
+      [fileResults],
+      todoInfo.todoConfig
+    );
+
+    const optionsForFile = {
+      ...writeTodoOptions,
+      todoConfig: todoInfo.todoConfig,
+      filePath: relative(baseDir, fileResults.filePath),
+    };
+
+    if (updateTodo) {
+      const { addedCount, removedCount } = writeTodos(
+        baseDir,
+        maybeTodos,
+        optionsForFile
+      );
+
+      todoInfo.added += addedCount;
+      todoInfo.removed += removedCount;
+    }
+
+    processResults(results, maybeTodos, {
+      updateTodo,
+      includeTodo,
+      shouldCleanTodos,
+      todoInfo,
+      writeTodoOptions: optionsForFile,
+    });
+  }
+
+  return printResults(results, {
+    updateTodo,
+    includeTodo,
+    shouldCleanTodos,
+    todoInfo,
+    writeTodoOptions,
+  });
+}
+
+/**
+ * Mutates all errors present in the todo dir to todos in the results array.
+ *
+ * @param results ESLint results array
+ */
+export function updateResults(
+  results: ESLint.LintResult[],
+  existingTodos: Map<string, TodoDataV2>
+): void {
+  for (const todo of [...existingTodos.values()]) {
+    const severity: Severity = getSeverity(todo);
+
+    if (severity === Severity.error) {
+      continue;
+    }
+
+    const result = findResult(results, todo);
+
+    if (!result) {
+      continue;
+    }
+
+    const message = result.messages.find(
+      (message) => message === todo.originalLintResult
+    );
+
+    if (!message) {
+      continue;
+    }
+
+    if (severity === Severity.warn) {
+      result.warningCount = result.warningCount + 1;
+
+      if (message.fix) {
+        result.fixableWarningCount = result.fixableWarningCount + 1;
+        result.fixableErrorCount -= 1;
+      }
+    } else {
+      result.todoCount = Number.isInteger(result.todoCount)
+        ? result.todoCount + 1
+        : 1;
+
+      if (message.fix) {
+        result.fixableTodoCount = Number.isInteger(result.fixableTodoCount)
+          ? result.fixableTodoCount + 1
+          : 1;
+        result.fixableErrorCount -= 1;
+      }
+    }
+
+    message.severity = <Linter.Severity>severity;
+
+    result.errorCount -= 1;
+  }
+}
+
+function processResults(
+  results: ESLint.LintResult[],
+  maybeTodos: Set<TodoDataV2>,
+  options: TodoFormatterOptions
+) {
+  const baseDir = getBaseDir();
+
+  if (todoStorageDirExists(baseDir)) {
+    const existingTodoFiles = readTodosForFilePath(
+      baseDir,
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      options.writeTodoOptions.filePath!
+    );
+    const { remove, stable, expired } = getTodoBatches(
+      maybeTodos,
+      existingTodoFiles,
+      options.writeTodoOptions
+    );
+
+    if (remove.size > 0 || expired.size > 0) {
+      if (options.shouldCleanTodos) {
+        applyTodoChanges(
+          getTodoStorageDirPath(baseDir),
+          new Map(),
+          new Map([...remove, ...expired])
+        );
+      } else {
+        for (const [, todo] of remove) {
+          pushResult(results, todo);
+        }
+      }
+    }
+
+    updateResults(results, stable);
+  }
+}
+
+export function buildMaybeTodos(
+  baseDir: string,
+  lintResults: ESLint.LintResult[],
+  todoConfig?: TodoConfig,
+  engine?: string
+): Set<TodoDataV2> {
+  const results = lintResults.filter((result) => result.messages.length > 0);
+
+  const todoData = results.reduce((converted, lintResult) => {
+    lintResult.messages.forEach((message: Linter.LintMessage) => {
+      if (message.severity !== Severity.error) {
+        return;
+      }
+
+      const range = {
+        start: {
+          line: message.line,
+          column: message.column,
+        },
+        end: {
+          line: message.endLine ?? message.line,
+          column: message.endColumn ?? message.column,
+        },
+      };
+      const todoDatum = buildTodoDatum(
+        baseDir,
+        {
+          engine: engine ?? 'eslint',
+          filePath: lintResult.filePath,
+          ruleId: message.ruleId || '',
+          range,
+          source: lintResult.source
+            ? getSourceForRange(
+                lintResult.source.match(LINES_PATTERN) || [],
+                range
+              )
+            : '',
+          originalLintResult: message,
+        },
+        todoConfig
+      );
+
+      converted.add(todoDatum);
+    });
+
+    return converted;
+  }, new Set<TodoDataV2>());
+
+  return todoData;
+}
+
+function getSourceForRange(source: string[], range: Range) {
+  const firstLine = range.start.line - 1;
+  const lastLine = range.end.line - 1;
+  let currentLine = firstLine - 1;
+  const firstColumn = range.start.column - 1;
+  const lastColumn = range.end.column - 1;
+  const src = [];
+  let line;
+
+  while (currentLine < lastLine) {
+    currentLine++;
+    line = source[currentLine];
+
+    if (currentLine === firstLine) {
+      if (firstLine === lastLine) {
+        src.push(line.slice(firstColumn, lastColumn));
+      } else {
+        src.push(line.slice(firstColumn));
+      }
+    } else if (currentLine === lastLine) {
+      src.push(line.slice(0, lastColumn));
+    } else {
+      src.push(line);
+    }
+  }
+
+  return src.join('');
+}
+
+function pushResult(results: ESLint.LintResult[], todo: TodoData) {
+  const resultForFile = findResult(results, todo);
+
+  const result: Linter.LintMessage = {
+    ruleId: 'invalid-todo-violation-rule',
+    message: `Todo violation passes \`${todo.ruleId}\` rule. Please run with \`CLEAN_TODO=1\` env var to remove this todo from the todo list.`,
+    severity: 2,
+    column: 0,
+    line: 0,
+  };
+
+  if (resultForFile) {
+    resultForFile.messages.push(result);
+    resultForFile.errorCount += 1;
+  } else {
+    results.push({
+      filePath: join(getBaseDir(), todo.filePath),
+      messages: [result],
+      errorCount: 1,
+      warningCount: 0,
+      todoCount: 0,
+      fixableErrorCount: 0,
+      fixableWarningCount: 0,
+      fixableTodoCount: 0,
+      usedDeprecatedRules: [],
+    });
+  }
+}
+
+function findResult(results: ESLint.LintResult[], todo: TodoData) {
+  return results.find(
+    (result) => relative(getBaseDir(), result.filePath) === todo.filePath
+  );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -278,15 +278,16 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@ember-template-lint/todo-utils@^10.0.0":
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/@ember-template-lint/todo-utils/-/todo-utils-10.0.0.tgz#085aafcf31ca04ba4d3a9460f088aed752b90ea8"
-  integrity sha512-US8VKnetBOl8KfKz+rXGsosz6rIETNwSz2F2frM8hIoJfF/d6ME1Iz1K7tPYZEE6SoKqZFlBs5XZPSmzRnabjA==
+"@ember-template-lint/todo-utils@11.0.0-beta.1":
+  version "11.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@ember-template-lint/todo-utils/-/todo-utils-11.0.0-beta.1.tgz#67d6a24e6e2328e00103f415c3c10d07bdcb4de2"
+  integrity sha512-HC/iH1HpeCQN+7A4b4oOJUdtq+j4s8xnmOIr5S/bXaUPSngbQmcE2MfMbFpanNyXQQ90avX0cOAkdcafLa928Q==
   dependencies:
     "@types/eslint" "^7.2.13"
     fs-extra "^9.1.0"
+    proper-lockfile "^4.1.2"
     slash "^3.0.0"
-    tslib "^2.2.0"
+    tslib "^2.3.1"
 
 "@eslint/eslintrc@^0.4.3":
   version "0.4.3"
@@ -5178,6 +5179,15 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.4"
 
+proper-lockfile@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/proper-lockfile/-/proper-lockfile-4.1.2.tgz#c8b9de2af6b2f1601067f98e01ac66baa223141f"
+  integrity sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==
+  dependencies:
+    graceful-fs "^4.2.4"
+    retry "^0.12.0"
+    signal-exit "^3.0.2"
+
 protocols@^1.1.0, protocols@^1.4.0:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/protocols/-/protocols-1.4.8.tgz#48eea2d8f58d9644a4a32caae5d5db290a075ce8"
@@ -5521,7 +5531,7 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
-retry@0.12.0:
+retry@0.12.0, retry@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
   integrity sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=
@@ -6220,10 +6230,10 @@ tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.2.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
-  integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
+tslib@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
+  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 tslib@~2.1.0:
   version "2.1.0"


### PR DESCRIPTION
As defined in https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/docs/single-file-storage.md, this update uses the new mode of todo storage: single file todos.