### PR TITLE
fix: quiet mode filter only returns errors

### DIFF
--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -275,7 +275,7 @@ function filterResults(results: ESLint.LintResult[]) {
   results.forEach((result) => {
     const filteredMessages = result.messages.filter(
       (message: Linter.LintMessage) => {
-        return message.severity !== Severity.warn;
+        return message.severity === Severity.error;
       }
     );
 


### PR DESCRIPTION
The quiet mode filter should only return error severity results, this ensures that todo severity results are excluded from the quiet results.

Currently the login filters out only warning results, which leave todos in the set of filtered results. This causes an incorrect errorCount and causes the todos being displayed in the `--quiet` output, which should not be the case.

fixes #415 