### PR TITLE
Add new compact-after-process feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
 
 
 
+## v4.0.4 (TBD)
+
+#### :rocket: Enhancement
+* [#477](https://github.com/lint-todo/eslint-formatter-todo/pull/477) Adds COMPACT_TODO_AFTER_PROCESS functionality to compact todo storage file after other formatter operations. ([@ngouy](https://github.com/ngouy))
+
+#### Committers: 1
+- Nathan Gouy ([@ngouy](https://github.com/ngouy))
 
 ## v4.0.3 (2022-11-15)
 

--- a/README.md
+++ b/README.md
@@ -49,10 +49,16 @@ If you want to opt out of this behavior, you can run with the `NO_CLEAN_TODO` en
 NO_CLEAN_TODO='1' eslint . --format @lint-todo/eslint-formatter-todo
 ```
 
-To compact the `.lint-todo` storage file, you can use the `COMPACT_TODO` environment variable.
+To compact the `.lint-todo` storage file without any other operation, you can use the `COMPACT_TODO` environment variable.
 
 ```bash
 COMPACT_TODO=1 eslint . --format @lint-todo/eslint-formatter-todo
+```
+
+To compact the `.lint-todo` storage file after other operations (such as cleanup), you can use the `COMPACT_TODO_AFTER_PROCESS` environment variable.
+
+```bash
+COMPACT_TODO_AFTER_PROCESS=1 CLEANUP_TODO=1 eslint . --format @lint-todo/eslint-formatter-todo
 ```
 
 ### Configuring Due Dates

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -18,6 +18,7 @@ export type TodoInfo =
   | {
       added: number;
       removed: number;
+      cleanedUp: number;
       todoConfig: TodoConfig | undefined;
     }
   | undefined;


### PR DESCRIPTION
This adds the ability to combine multiple operation, and then compact the result

So for example we can both cleanup and compact at the same time